### PR TITLE
Pkmn debug into main

### DIFF
--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -64,7 +64,7 @@ struct AlphaBetaForce : Types
         const Real max_val{1};
         // bool (*const terminate)(typename Types::PRNG &, const Data &) = &dont_terminate;
 
-        const size_t max_tries = (1 << 12);
+        const size_t max_tries = (1 << 0);
         // const typename Types::ObsHash hasher{};
 
         Search() {}
@@ -179,6 +179,8 @@ struct AlphaBetaForce : Types
                         }
                     }
                     LRSNash::solve(matrix, row_solution, col_solution);
+                    std::cout << "solved exactly" << std::endl;
+                    matrix.print();
                 }
                 else
                 {
@@ -197,6 +199,10 @@ struct AlphaBetaForce : Types
                     LRSNash::solve(alpha_matrix, row_solution, temp);
                     temp.clear();
                     LRSNash::solve(beta_matrix, temp, col_solution);
+                    std::cout << "solved exactly: alpha" << std::endl;
+                    alpha_matrix.print();
+                    std::cout << "not solved exactly: beta" << std::endl;
+                    beta_matrix.print();
                 }
 
                 std::pair<int, Real>

--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -38,7 +38,11 @@ struct AlphaBetaForce : Types
             size_t,
             Branch>
             branches{};
+
+        Data () {}
+        Data (Data &&) {}
     };
+    
     struct MatrixNode
     {
         DataMatrix<Data> chance_data_matrix{};
@@ -327,10 +331,12 @@ struct AlphaBetaForce : Types
                         {
                             produced_new_branch = true;
 
-                            data.branches.emplace(
-                                std::piecewise_construct,
-                                std::forward_as_tuple(obs_hash),
-                                std::forward_as_tuple(state_copy, seed));
+                            // data.branches.emplace(
+                            //     std::piecewise_construct,
+                            //     std::forward_as_tuple(obs_hash),
+                            //     std::forward_as_tuple(state_copy, seed));
+                            data.branches.try_emplace(
+                                obs_hash, state_copy, seed);
                             Branch &new_branch = data.branches.at(obs_hash);
 
                             new_branch.matrix_node->depth = matrix_node->depth + 1;
@@ -451,10 +457,12 @@ struct AlphaBetaForce : Types
                         {
                             produced_new_branch = true;
 
-                            data.branches.emplace(
-                                std::piecewise_construct,
-                                std::forward_as_tuple(obs_hash),
-                                std::forward_as_tuple(state_copy, seed));
+                            // data.branches.emplace(
+                            //     std::piecewise_construct,
+                            //     std::forward_as_tuple(obs_hash),
+                            //     std::forward_as_tuple(state_copy, seed));
+                            data.branches.try_emplace(
+                                obs_hash, state_copy, seed);
                             Branch &new_branch = data.branches.at(obs_hash);
 
                             new_branch.matrix_node->depth = matrix_node->depth + 1;
@@ -567,10 +575,12 @@ struct AlphaBetaForce : Types
 
                 if (data.branches.find(obs_hash) == data.branches.end())
                 {
-                    data.branches.emplace(
-                        std::piecewise_construct,
-                        std::forward_as_tuple(obs_hash),
-                        std::forward_as_tuple(state_copy, seed));
+                    // data.branches.emplace(
+                    //     std::piecewise_construct,
+                    //     std::forward_as_tuple(obs_hash),
+                    //     std::forward_as_tuple(state_copy, seed));
+                    data.branches.try_emplace(
+                        obs_hash, state_copy, seed);
                     Branch &new_branch = data.branches.at(obs_hash);
 
                     new_branch.matrix_node->depth = matrix_node->depth + 1;

--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -274,6 +274,8 @@ struct AlphaBeta : Types
                 const bool is_row_idx_in_I = (std::find(I.begin(), I.end(), row_idx) != I.end());
                 const typename Types::Action row_action = state.row_actions[row_idx];
 
+                // For each row, there are multiple chance nodes. Priority refers to how much prob is left to explore
+                // If row_idx \in I, that means a perfious iteration already ran `try_solve_chance_node`
                 Real max_priority{0}, expected_score{0}, total_unexplored{0};
                 std::vector<Real> priority_scores;
                 int col_idx, best_i;

--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -69,7 +69,9 @@ struct AlphaBetaForce : Types
 
         Search() {}
 
-        Search(Real min_val, Real max_val, size_t max_tries) : min_val(min_val), max_val(max_val), max_tries{max_tries} {}
+        Search (size_t max_tries) : max_tries{max_tries} {}
+
+        Search(Real min_val, Real max_val, size_t max_tries = (1 << 6)) : min_val(min_val), max_val(max_val), max_tries{max_tries} {}
 
         // Search(
         //     Real min_val, Real max_val,

--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -181,8 +181,6 @@ struct AlphaBetaForce : Types
                         }
                     }
                     LRSNash::solve(matrix, row_solution, col_solution);
-                    std::cout << "solved exactly" << std::endl;
-                    matrix.print();
                 }
                 else
                 {
@@ -264,6 +262,9 @@ struct AlphaBetaForce : Types
 
             matrix_node->row_pricipal_idx = I[std::distance(row_solution.begin(), std::max_element(row_solution.begin(), row_solution.end()))];
             matrix_node->col_pricipal_idx = J[std::distance(col_solution.begin(), std::max_element(col_solution.begin(), col_solution.end()))];
+
+            alpha.canonicalize();
+            beta.canonicalize();
 
             return {alpha, beta};
         }
@@ -385,6 +386,8 @@ struct AlphaBetaForce : Types
                 }
 
                 expected_value += total_unexplored * beta;
+
+                expected_value.canonicalize();
 
                 if (expected_value >= alpha || (best_row_idx == -1 && fuzzy_equals(expected_value, alpha)))
                 {
@@ -513,6 +516,8 @@ struct AlphaBetaForce : Types
                 }
 
                 expected_value += total_unexplored * alpha;
+
+                expected_value.canonicalize();
 
                 if (expected_value <= beta || (best_col_idx == -1 && fuzzy_equals(expected_value, beta)))
                 {

--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -64,12 +64,12 @@ struct AlphaBetaForce : Types
         const Real max_val{1};
         // bool (*const terminate)(typename Types::PRNG &, const Data &) = &dont_terminate;
 
-        const size_t max_tries = (1 << 0);
+        const size_t max_tries = (1 << 6);
         // const typename Types::ObsHash hasher{};
 
         Search() {}
 
-        Search(Real min_val, Real max_val) : min_val(min_val), max_val(max_val) {}
+        Search(Real min_val, Real max_val, size_t max_tries) : min_val(min_val), max_val(max_val), max_tries{max_tries} {}
 
         // Search(
         //     Real min_val, Real max_val,
@@ -199,10 +199,6 @@ struct AlphaBetaForce : Types
                     LRSNash::solve(alpha_matrix, row_solution, temp);
                     temp.clear();
                     LRSNash::solve(beta_matrix, temp, col_solution);
-                    std::cout << "solved exactly: alpha" << std::endl;
-                    alpha_matrix.print();
-                    std::cout << "not solved exactly: beta" << std::endl;
-                    beta_matrix.print();
                 }
 
                 std::pair<int, Real>
@@ -306,7 +302,7 @@ struct AlphaBetaForce : Types
                         (skip_exploration || (data.tries >= max_tries))
                             ? Real{0}
                             : Real{col_strategy[j] * data.unexplored};
-                    total_unexplored += priority;
+                    total_unexplored += col_strategy[j] * data.unexplored;
                     exploration_priorities.push_back(priority);
                     if (priority > max_priority)
                     {
@@ -386,6 +382,8 @@ struct AlphaBetaForce : Types
                     }
                 }
 
+                expected_value += total_unexplored * beta;
+
                 if (expected_value >= alpha || (best_row_idx == -1 && fuzzy_equals(expected_value, alpha)))
                 {
                     best_row_idx = row_idx;
@@ -432,7 +430,7 @@ struct AlphaBetaForce : Types
                             ? Real{0}
                             : Real{row_strategy[i] * data.unexplored};
 
-                    total_unexplored += priority;
+                    total_unexplored += row_strategy[i] * data.unexplored;
                     exploration_priorities.push_back(priority);
                     if (priority > max_priority)
                     {
@@ -511,6 +509,8 @@ struct AlphaBetaForce : Types
                         }
                     }
                 }
+
+                expected_value += total_unexplored * alpha;
 
                 if (expected_value <= beta || (best_col_idx == -1 && fuzzy_equals(expected_value, beta)))
                 {

--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -61,7 +61,7 @@ struct AlphaBetaForce : Types
         // bool (*const terminate)(typename Types::PRNG &, const Data &) = &dont_terminate;
 
         const size_t max_tries = (1 << 12);
-        const typename Types::ObsHash hasher{};
+        // const typename Types::ObsHash hasher{};
 
         Search() {}
 
@@ -79,9 +79,6 @@ struct AlphaBetaForce : Types
             MatrixNode &root) const
         {
             typename Types::State state_copy{state};
-            root.chance_data_matrix.fill(1, 1);
-            Data &data = root.chance_data_matrix[0];
-            std::unordered_map<size_t, Branch> &branches = data.branches;
             return double_oracle(max_depth, device, state_copy, model, &root, min_val, max_val);
         }
 
@@ -324,7 +321,7 @@ struct AlphaBetaForce : Types
                         const typename Types::Seed seed{device.uniform_64()};
                         state_copy.randomize_transition(seed);
                         state_copy.apply_actions(row_action, col_action);
-                        const size_t obs_hash = hasher(state_copy.get_obs());
+                        const size_t obs_hash = state_copy.get_obs().get();
 
                         if (data.branches.find(obs_hash) == data.branches.end())
                         {
@@ -448,7 +445,7 @@ struct AlphaBetaForce : Types
                         const typename Types::Seed seed{device.uniform_64()};
                         state_copy.randomize_transition(seed);
                         state_copy.apply_actions(row_action, col_action);
-                        const size_t obs_hash = hasher(state_copy.get_obs());
+                        const size_t obs_hash = state_copy.get_obs().get();
 
                         if (data.branches.find(obs_hash) == data.branches.end())
                         {
@@ -566,7 +563,7 @@ struct AlphaBetaForce : Types
                 const typename Types::Seed seed{device.uniform_64()};
                 state_copy.randomize_transition(seed);
                 state_copy.apply_actions(row_action, col_action);
-                const size_t obs_hash = hasher(state_copy.get_obs());
+                const size_t obs_hash = state_copy.get_obs().get();
 
                 if (data.branches.find(obs_hash) == data.branches.end())
                 {

--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -1,0 +1,604 @@
+#pragma once
+
+#include <libpinyon/lrslib.hh>
+#include <types/matrix.hh>
+#include <algorithm/algorithm.hh>
+#include <tree/tree.hh>
+
+// #include <algorithm
+#include <ranges>
+#include <concepts>
+#include <assert.h>
+
+template <CONCEPT(IsSingleModelTypes, Types), template <typename...> typename NodePair = DefaultNodes>
+struct AlphaBeta : Types
+{
+    struct MatrixNode;
+    struct Branch
+    {
+        typename Types::Prob prob;
+        typename Types::Obs obs;
+        typename Types::Seed seed;
+        std::unique_ptr<typename Types::MatrixNode> matrix_node;
+
+        Branch(
+            const Types::State &state,
+            const Types::Seed seed)
+            : prob{state.prob}, obs{state.get_obs()}, seed{seed}, matrix_node{std::make_unique<typename Types::MatrixNode>()} {}
+    };
+
+    struct Data
+    {
+        Types::Prob unexplored{1};
+        typename Types::Real alpha_explored{0}, beta_explored{0};
+        // int next_chance_idx = 0;
+        size_t tries = 0;
+        friend std::ostream &operator<<(std::ostream &os, const Data &data)
+        {
+            os << '(' << data.alpha_explored << " " << data.beta_explored << " " << data.unexplored << ")";
+            return os;
+        }
+
+        std::unordered_map<
+            size_t,
+            Branch>
+            branches{};
+    };
+    struct MatrixNode
+    {
+        DataMatrix<Data> chance_data_matrix{};
+        Types::VectorReal row_solution{}, col_solution{};
+        unsigned int depth = 0;
+
+        int row_pricipal_idx = 0, col_pricipal_idx = 0;
+        std::vector<int> I{}, J{};
+
+        typename Types::Value solved_value;
+    };
+
+    class Search
+    {
+    public:
+        using Real = typename Types::Real; // many uses
+
+        const Real min_val{0}; // don't need to use the Game values if you happen to know that State's
+        const Real max_val{1};
+        bool (*const terminate)(typename Types::PRNG &, const Data &) = &dont_terminate;
+
+        Search() {}
+
+        Search(Real min_val, Real max_val) : min_val(min_val), max_val(max_val) {}
+
+        Search(
+            Real min_val, Real max_val,
+            bool (*const terminate)(typename Types::PRNG &, const Data &)) : min_val(min_val), max_val(max_val), terminate{terminate} {}
+
+        auto run(
+            const size_t max_depth, // let it overflow to super big number
+            Types::PRNG &device,
+            const typename Types::State &state,
+            typename Types::Model &model,
+            MatrixNode &root) const
+        {
+            typename Types::State state_copy = state;
+            return double_oracle(max_depth, device, state_copy, model, &root, min_val, max_val);
+        }
+
+        std::pair<Real, Real>
+        double_oracle(
+            const size_t max_depth,
+            Types::PRNG &device,
+            Types::State &state,
+            typename Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha,
+            Real beta) const
+        {
+            if (state.is_terminal())
+            {
+                const typename Types::Value payoff = state.get_payoff();
+                matrix_node->solved_value = payoff;
+                return {payoff.get_row_value(), payoff.get_row_value()};
+            }
+            // stats is given proper depth before recursive call - or initialized with 0
+            if (matrix_node->depth >= max_depth)
+            {
+                typename Types::ModelOutput model_output;
+                model.inference(std::move(state), model_output);
+                return {model_output.value.get_row_value(), model_output.value.get_row_value()};
+            }
+
+            state.get_actions();
+            const size_t rows = state.row_actions.size();
+            const size_t cols = state.col_actions.size();
+            // assumes double expand is ok (it is?)
+            matrix_node->expand(rows, cols);
+
+            std::vector<int> &I = matrix_node->I;
+            std::vector<int> &J = matrix_node->J;
+            // current best strategy. used to calculate best response values
+            typename Types::VectorReal &row_solution = matrix_node->row_solution;
+            typename Types::VectorReal &col_solution = matrix_node->col_solution;
+
+            // I,J are the only places we can use prior solve info
+            // either already there or init to 0
+            I.push_back(matrix_node->row_pricipal_idx);
+            J.push_back(matrix_node->col_pricipal_idx);
+
+            bool smaller_bounds = false;
+            bool new_action = true;
+            int latest_row_idx = matrix_node->row_pricipal_idx;
+            int latest_col_idx = matrix_node->col_pricipal_idx;
+            bool solved_exactly = true;
+            // when solving chance nodes for the official strategies,
+            // we don't always solve all of them
+            while (!fuzzy_equals(alpha, beta) && (smaller_bounds || new_action))
+            {
+
+                // get entry values/bounds for newly expanded sub game, use last added actions
+
+                for (const int row_idx : I)
+                {
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx, latest_col_idx);
+                    solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, row_idx, latest_col_idx);
+                }
+
+                for (const int col_idx : J)
+                {
+                    Data &data = matrix_node->chance_data_matrix.get(latest_row_idx, col_idx);
+                    solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, latest_row_idx, col_idx);
+                }
+
+                // solve newly expanded and explored game
+
+                int entry_idx = 0;
+                if (solved_exactly)
+                {
+                    typename Types::MatrixValue matrix{I.size(), J.size()};
+                    for (auto row_idx : I)
+                    {
+                        for (auto col_idx : J)
+                        {
+                            const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+                            matrix[entry_idx] = data.alpha_explored;
+                            ++entry_idx;
+                        }
+                    }
+                    LRSNash::solve(matrix, row_solution, col_solution);
+                }
+                else
+                {
+                    typename Types::MatrixValue alpha_matrix{I.size(), J.size()}, beta_matrix{I.size(), J.size()};
+                    for (auto row_idx : I)
+                    {
+                        for (auto col_idx : J)
+                        {
+                            const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+                            alpha_matrix[entry_idx] = static_cast<Real>(data.alpha_explored + data.unexplored * min_val);
+                            beta_matrix[entry_idx] = static_cast<Real>(data.beta_explored + data.unexplored * max_val);
+                            ++entry_idx;
+                        }
+                    }
+                    typename Types::VectorReal temp;
+                    LRSNash::solve(alpha_matrix, row_solution, temp);
+                    temp.clear();
+                    LRSNash::solve(beta_matrix, temp, col_solution);
+                }
+
+                std::pair<int, Real>
+                    iv = best_response_row(
+                        max_depth,
+                        device,
+                        state,
+                        model,
+                        matrix_node,
+                        alpha, max_val,
+                        col_solution);
+
+                std::pair<int, Real>
+                    jv = best_response_col(
+                        max_depth,
+                        device,
+                        state,
+                        model,
+                        matrix_node,
+                        min_val, beta,
+                        row_solution);
+
+                // prune this node if no best response is as good as alpha/beta
+                if (iv.first == -1)
+                {
+                    return {min_val, min_val};
+                }
+                if (jv.first == -1)
+                {
+                    return {max_val, max_val};
+                }
+
+                smaller_bounds = false;
+                new_action = false;
+                latest_row_idx = iv.first;
+                latest_col_idx = jv.first;
+
+                if (std::find(I.begin(), I.end(), latest_row_idx) == I.end())
+                {
+                    I.push_back(latest_row_idx);
+                    new_action = true;
+                }
+                if (std::find(J.begin(), J.end(), latest_col_idx) == J.end())
+                {
+                    J.push_back(latest_col_idx);
+                    new_action = true;
+                }
+                if (jv.second > alpha)
+                {
+                    alpha = jv.second;
+                    smaller_bounds = true;
+                }
+                if (iv.second < beta)
+                {
+                    beta = iv.second;
+                    smaller_bounds = true;
+                }
+            }
+            // Used to be if max_depth != -1 here
+            // meaning only necessary for iterative deepening
+            matrix_node->row_pricipal_idx = I[std::distance(row_solution.begin(), std::max_element(row_solution.begin(), row_solution.end()))];
+            matrix_node->col_pricipal_idx = J[std::distance(col_solution.begin(), std::max_element(col_solution.begin(), col_solution.end()))];
+
+            // delete stuff?
+
+            return {alpha, beta};
+        }
+
+        std::pair<int, Real>
+        best_response_row(
+            const size_t max_depth,
+            Types::PRNG &device,
+            const typename Types::State &state,
+            typename Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha, Real beta,
+            Types::VectorReal &col_strategy) const
+        {
+            std::vector<int> &I = matrix_node->I;
+            std::vector<int> &J = matrix_node->J;
+            int best_row_idx = -1;
+
+            for (int row_idx = 0; row_idx < state.row_actions.size(); ++row_idx)
+            {
+                const bool is_row_idx_in_I = (std::find(I.begin(), I.end(), row_idx) != I.end());
+                const typename Types::Action row_action = state.row_actions[row_idx];
+
+                Real max_priority{0}, expected_score{0}, total_unexplored{0};
+                std::vector<Real> priority_scores;
+                int col_idx, best_i;
+                for (int i = 0; i < J.size(); ++i)
+                {
+                    const int col_idx_temp = J[i];
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx_temp);
+                    expected_score += col_strategy[i] * data.beta_explored;
+                    Real priority;
+                    if (is_row_idx_in_I)
+                    {
+                        priority = typename Types::Q{0};
+                    }
+                    else
+                    {
+                        priority = col_strategy[i] * data.unexplored;
+                    }
+                    total_unexplored += priority;
+                    priority_scores.push_back(priority);
+                    if (priority > max_priority)
+                    {
+                        col_idx = col_idx_temp;
+                        max_priority = priority;
+                        best_i = i;
+                    }
+                }
+
+                while (
+                    (max_priority > Real{Rational<>{0}}) &&
+                    (Real{expected_score + beta * total_unexplored} >= alpha))
+                {
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+                    const typename Types::Action col_action = state.col_actions[col_idx];
+                    if (data.chance_actions.size() == 0)
+                    {
+                        state.get_chance_actions(row_action, col_action, data.chance_actions);
+                    }
+                    if (data.next_chance_idx >= data.chance_actions.size())
+                    {
+                        break;
+                    }
+                    typename Types::State state_copy = state;
+                    state_copy.apply_actions(row_action, col_action, data.chance_actions[data.next_chance_idx++]);
+                    ChanceNode *chance_node = matrix_node->access(row_idx, col_idx);
+                    MatrixNode *matrix_node_next = chance_node->access(state_copy.get_obs());
+                    matrix_node_next->matrix_node->depth = matrix_node->depth + 1;
+                    const typename Types::Prob prob = state_copy.prob;
+
+                    auto alpha_beta_pair = double_oracle(
+                        max_depth,
+                        device,
+                        state_copy,
+                        model,
+                        matrix_node_next,
+                        min_val, max_val);
+
+                    data.alpha_explored += alpha_beta_pair.first * prob;
+                    data.beta_explored += alpha_beta_pair.second * prob;
+                    expected_score += alpha_beta_pair.second * prob * col_strategy[best_i];
+
+                    data.unexplored -= prob;
+                    total_unexplored -= prob * col_strategy[best_i];
+                    priority_scores[best_i] -= prob * col_strategy[best_i];
+
+                    // TODO fails but likely not serious.
+                    // assert(data.unexplored >= Real{0});
+                    // assert(total_unexplored >= Real{0});
+
+                    max_priority = typename Types::Q{0};
+                    for (int i = 0; i < J.size(); ++i)
+                    {
+                        const Real priority = priority_scores[i];
+                        if (priority > max_priority)
+                        {
+                            col_idx = J[i];
+                            max_priority = priority;
+                            best_i = i;
+                        }
+                    }
+                }
+
+                if (expected_score >= alpha || (best_row_idx == -1 && fuzzy_equals(expected_score, alpha)))
+                {
+                    best_row_idx = row_idx;
+                    alpha = expected_score;
+                }
+            }
+            return {best_row_idx, alpha};
+        }
+
+        std::pair<int, Real> best_response_col(
+            const size_t max_depth,
+            Types::PRNG &device,
+            const typename Types::State &state,
+            typename Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha, Real beta,
+            Types::VectorReal &row_strategy) const
+        {
+            MatrixStats &stats = matrix_node->stats;
+            std::vector<int> &I = matrix_node->I;
+            std::vector<int> &J = matrix_node->J;
+            int best_col_idx = -1;
+
+            for (int col_idx = 0; col_idx < state.col_actions.size(); ++col_idx)
+            {
+                bool col_idx_in_J = (std::find(J.begin(), J.end(), col_idx) != J.end());
+                const typename Types::Action col_action = state.col_actions[col_idx];
+
+                Real max_priority{0}, expected_score{0}, total_unexplored{0};
+                std::vector<Real> priority_scores;
+                int row_idx, best_i;
+                for (int i = 0; i < I.size(); ++i)
+                {
+                    const int row_idx_temp = I[i];
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx_temp, col_idx);
+                    expected_score += row_strategy[i] * data.alpha_explored;
+                    Real priority;
+                    if (col_idx_in_J)
+                    {
+                        priority = typename Types::Q{0};
+                    }
+                    else
+                    {
+                        priority = row_strategy[i] * data.unexplored;
+                    }
+                    total_unexplored += priority;
+                    priority_scores.push_back(priority);
+                    if (priority > max_priority)
+                    {
+                        row_idx = row_idx_temp;
+                        max_priority = priority;
+                        best_i = i;
+                    }
+                }
+
+                while (
+                    fuzzy_greater(total_unexplored, Real{Rational<>{0}}) &&
+                    (Real{expected_score + alpha * total_unexplored} <= beta))
+                {
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+                    const typename Types::Action row_action = state.row_actions[row_idx];
+                    if (data.chance_actions.size() == 0)
+                    {
+                        state.get_chance_actions(row_action, col_action, data.chance_actions);
+                    }
+
+                    if (data.next_chance_idx >= data.chance_actions.size())
+                    {
+                        break;
+                    }
+                    typename Types::State state_copy = state;
+                    state_copy.apply_actions(row_action, col_action, data.chance_actions[data.next_chance_idx++]);
+                    ChanceNode *chance_node = matrix_node->access(row_idx, col_idx);
+                    MatrixNode *matrix_node_next = chance_node->access(state_copy.get_obs());
+                    matrix_node_next->matrix_node->depth = matrix_node->depth + 1;
+                    const typename Types::Prob prob = state_copy.prob;
+
+                    auto alpha_beta_pair = double_oracle(
+                        max_depth,
+                        device,
+                        state_copy,
+                        model,
+                        matrix_node_next,
+                        min_val, max_val);
+
+                    data.alpha_explored += alpha_beta_pair.first * prob;
+                    data.beta_explored += alpha_beta_pair.second * prob;
+                    expected_score += alpha_beta_pair.first * prob * row_strategy[best_i];
+
+                    data.unexplored -= prob;
+                    total_unexplored -= prob * row_strategy[best_i];
+                    priority_scores[best_i] -= prob * row_strategy[best_i];
+
+                    // assert(data.unexplored >= Real{0});
+                    // assert(total_unexplored >= Real{0});
+
+                    max_priority = Real{Rational<>{0}};
+                    for (int i = 0; i < I.size(); ++i)
+                    {
+                        const Real priority = priority_scores[i];
+                        if (priority > max_priority)
+                        {
+                            row_idx = I[i];
+                            max_priority = priority;
+                            best_i = i;
+                        }
+                    }
+                }
+
+                if (expected_score <= beta || (best_col_idx == -1 && fuzzy_equals(expected_score, beta)))
+                {
+                    best_col_idx = col_idx;
+                    beta = expected_score;
+                }
+            }
+            return {best_col_idx, beta};
+        }
+
+    private:
+        template <template <typename> typename Wrapper, typename T>
+        inline bool fuzzy_equals(Wrapper<T> x, Wrapper<T> y) const
+        {
+            if constexpr (std::is_same_v<T, mpq_class>)
+            {
+                mpq_ptr a = x.value.get_mpq_t();
+                mpq_ptr b = y.value.get_mpq_t();
+                mpq_canonicalize(a);
+                mpq_canonicalize(b);
+                bool answer = mpq_equal(a, b);
+                return answer;
+            }
+            else
+            {
+                static const Real epsilon{Rational{1, 1 << 24}};
+                static const Real neg_epsilon{Rational{-1, 1 << 24}};
+                Wrapper<T> z{x - y};
+                return neg_epsilon < z && z < epsilon;
+            }
+        }
+
+        template <template <typename> typename Wrapper, typename T>
+        inline bool fuzzy_greater(Wrapper<T> x, Wrapper<T> y) const
+        {
+            if constexpr (std::is_same_v<T, mpq_class>)
+            {
+                return x > y;
+            }
+            else
+            {
+                static const Real epsilon{Rational{1, 1 << 24}};
+                bool a = x > y + epsilon;
+                return a;
+            }
+        }
+
+        inline bool try_solve_chance_branches(
+            const size_t max_depth,
+            Types::PRNG &device,
+            const typename Types::State &state, // TODO const?
+            Types::Model &model,
+            MatrixNode *matrix_node,
+            int row_idx, int col_idx) const
+        {
+            Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+
+            if (data.unexplored > typename Types::Prob{0})
+            {
+                auto row_action = state.row_actions[row_idx];
+                auto col_action = state.col_actions[col_idx];
+
+
+
+                auto &chance_actions = data.chance_actions;
+                if (chance_actions.size() == 0)
+                {
+                    state.get_chance_actions(row_action, col_action, chance_actions); // TODO arg order
+                }
+
+                // go through all chance actions
+                for (; data.next_chance_idx < chance_actions.size() && !terminate(device, data); ++data.next_chance_idx)
+                {
+                    if (chance_actions.size() <= data.next_chance_idx)
+                    {
+                        break;
+                    }
+
+                    const typename Types::Obs chance_action = chance_actions[data.next_chance_idx];
+                    typename Types::State state_copy = state;
+                    state_copy.apply_actions(row_action, col_action, chance_action);
+                    MatrixNode *matrix_node_next = chance_node->access(state_copy.get_obs());
+                    matrix_node_next->matrix_node->depth = matrix_node->depth + 1;
+                    const typename Types::Prob prob = state_copy.prob;
+
+                    auto alpha_beta = double_oracle(max_depth, device, state_copy, model, matrix_node_next, min_val, max_val);
+
+                    data.alpha_explored += alpha_beta.first * prob;
+                    data.beta_explored += alpha_beta.second * prob;
+                    data.unexplored -= prob;
+                }
+            }
+
+            bool solved_exactly = (data.alpha_explored == data.beta_explored) && (data.unexplored == Real{Rational<>{0}});
+            return solved_exactly;
+        };
+
+        Real row_alpha_beta(
+            Types::State &state,
+            typename Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha,
+            Real beta)
+        {
+            return max_val;
+        }
+
+        Real col_alpha_beta(
+            Types::State &state,
+            typename Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha,
+            Real beta)
+        {
+            return min_val;
+        }
+        // Serialized AlphaBeta, TODO
+
+        static bool dont_terminate(
+            Types::PRNG &,
+            const Data &)
+        {
+            return false;
+        };
+
+        static bool after_some_time(
+            Types::PRNG &device,
+            const Data &data)
+        {
+            const typename Types::Prob x{Rational<>{1, 4}};
+            return (data.next_chance_idx > 1 &&
+                    data.unexplored < x);
+        }
+
+        static bool thing(
+            Types::PRNG &device,
+            const Data &data)
+        {
+            // return (data.unexplored + (1 / 2) > )
+            return false;
+        }
+    };
+};

--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -5,7 +5,6 @@
 #include <algorithm/algorithm.hh>
 #include <tree/tree.hh>
 
-// #include <algorithm
 #include <ranges>
 #include <concepts>
 #include <assert.h>
@@ -21,30 +20,19 @@ struct AlphaBetaForce : Types
         typename Types::Seed seed;
         std::unique_ptr<MatrixNode> matrix_node;
 
-        // Branch(const Branch &) = delete;
-        // Branch &operator=(const Branch &) = delete;
-
         Branch(
             const Types::State &state,
             const Types::Seed &seed)
-            // : prob{state.prob}, obs{state.get_obs()}, seed{seed}
-            // matrix_node{std::make_unique<MatrixNode>()} 
-            {}
-    
-        Branch(const Types::State &state) {}
+            : prob{state.prob}, obs{state.get_obs()}, seed{seed}, matrix_node{std::make_unique<MatrixNode>()}
+        {
+        }
     };
 
     struct Data
     {
-        // Types::Prob unexplored{1};
-        // typename Types::Real alpha_explored{0}, beta_explored{0};
-        // // int next_chance_idx = 0;
-        // size_t tries = 0;
-        // friend std::ostream &operator<<(std::ostream &os, const Data &data)
-        // {
-        //     os << '(' << data.alpha_explored << " " << data.beta_explored << " " << data.unexplored << ")";
-        //     return os;
-        // }
+        Types::Prob unexplored{1};
+        typename Types::Real alpha_explored{0}, beta_explored{0};
+        size_t tries = 0;
 
         std::unordered_map<
             size_t,
@@ -54,13 +42,13 @@ struct AlphaBetaForce : Types
     struct MatrixNode
     {
         DataMatrix<Data> chance_data_matrix{};
-        // Types::VectorReal row_solution{}, col_solution{};
-        // unsigned int depth = 0;
+        Types::VectorReal row_solution{}, col_solution{};
+        unsigned int depth = 0;
 
-        // int row_pricipal_idx = 0, col_pricipal_idx = 0;
-        // std::vector<int> I{}, J{};
+        int row_pricipal_idx = 0, col_pricipal_idx = 0;
+        std::vector<int> I{}, J{};
 
-        // typename Types::Real alpha, beta;
+        typename Types::Real alpha, beta;
     };
 
     class Search
@@ -94,545 +82,564 @@ struct AlphaBetaForce : Types
             root.chance_data_matrix.fill(1, 1);
             Data &data = root.chance_data_matrix[0];
             std::unordered_map<size_t, Branch> &branches = data.branches;
-            branches.emplace(0, state_copy, 0);
-            // return double_oracle(max_depth, device, state_copy, model, &root, min_val, max_val);
+            return double_oracle(max_depth, device, state_copy, model, &root, min_val, max_val);
         }
 
-    //     std::pair<Real, Real>
-    //     double_oracle(
-    //         const size_t max_depth,
-    //         Types::PRNG &device,
-    //         Types::State &state,
-    //         Types::Model &model,
-    //         MatrixNode *matrix_node,
-    //         Real alpha,
-    //         Real beta) const
-    //     {
-    //         if (state.is_terminal())
-    //         {
-    //             const typename Types::Value payoff = state.get_payoff();
-    //             matrix_node->alpha = payoff.get_row_value();
-    //             matrix_node->beta = payoff.get_row_value();
-    //             return {payoff.get_row_value(), payoff.get_row_value()};
-    //         }
-
-    //         if (matrix_node->depth >= max_depth)
-    //         {
-    //             typename Types::ModelOutput model_output;
-    //             model.inference(std::move(state), model_output);
-    //             matrix_node->alpha = model_output.value.get_row_value();
-    //             matrix_node->beta = model_output.value.get_row_value();
-    //             return {model_output.value.get_row_value(), model_output.value.get_row_value()};
-    //         }
-
-    //         state.get_actions();
-    //         const size_t rows = state.row_actions.size();
-    //         const size_t cols = state.col_actions.size();
-    //         // assumes double expand is ok (it is?)
-    //         // matrix_node->expand(rows, cols);
-    //         matrix_node->chance_data_matrix.fill(rows, cols);
-
-    //         std::vector<int> &I = matrix_node->I;
-    //         std::vector<int> &J = matrix_node->J;
-    //         // current best strategy. used to calculate best response values
-    //         // entries correspond to I, J entires and order. It is a permuted submatrix of the full matrix, basically.
-    //         typename Types::VectorReal &row_solution = matrix_node->row_solution;
-    //         typename Types::VectorReal &col_solution = matrix_node->col_solution;
-
-    //         // I,J are the only places we can use prior solve info
-    //         // either already there or init to 0
-    //         I.push_back(matrix_node->row_pricipal_idx);
-    //         J.push_back(matrix_node->col_pricipal_idx);
-
-    //         bool smaller_bounds = false;
-    //         bool new_action = true;
-    //         int latest_row_idx = matrix_node->row_pricipal_idx;
-    //         int latest_col_idx = matrix_node->col_pricipal_idx;
-    //         bool solved_exactly = true;
-
-    //         while (!fuzzy_equals(alpha, beta) && (smaller_bounds || new_action))
-    //         {
-
-    //             // get entry values/bounds for newly expanded sub game, use last added actions
-
-    //             for (const int row_idx : I)
-    //             {
-    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx, latest_col_idx);
-    //                 solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, row_idx, latest_col_idx);
-    //             }
-
-    //             for (const int col_idx : J)
-    //             {
-    //                 Data &data = matrix_node->chance_data_matrix.get(latest_row_idx, col_idx);
-    //                 solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, latest_row_idx, col_idx);
-    //             }
-
-    //             // solve newly expanded and explored game
-
-    //             int entry_idx = 0;
-    //             if (solved_exactly)
-    //             {
-    //                 typename Types::MatrixValue matrix{I.size(), J.size()};
-    //                 for (auto row_idx : I)
-    //                 {
-    //                     for (auto col_idx : J)
-    //                     {
-    //                         const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-    //                         matrix[entry_idx] = data.alpha_explored;
-    //                         ++entry_idx;
-    //                     }
-    //                 }
-    //                 LRSNash::solve(matrix, row_solution, col_solution);
-    //             }
-    //             else
-    //             {
-    //                 typename Types::MatrixValue alpha_matrix{I.size(), J.size()}, beta_matrix{I.size(), J.size()};
-    //                 for (auto row_idx : I)
-    //                 {
-    //                     for (auto col_idx : J)
-    //                     {
-    //                         const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-    //                         alpha_matrix[entry_idx] = static_cast<Real>(data.alpha_explored + data.unexplored * min_val);
-    //                         beta_matrix[entry_idx] = static_cast<Real>(data.beta_explored + data.unexplored * max_val);
-    //                         ++entry_idx;
-    //                     }
-    //                 }
-    //                 typename Types::VectorReal temp;
-    //                 LRSNash::solve(alpha_matrix, row_solution, temp);
-    //                 temp.clear();
-    //                 LRSNash::solve(beta_matrix, temp, col_solution);
-    //             }
-
-    //             std::pair<int, Real>
-    //                 iv = best_response_row(
-    //                     max_depth,
-    //                     device,
-    //                     state,
-    //                     model,
-    //                     matrix_node,
-    //                     alpha, max_val,
-    //                     col_solution);
-
-    //             std::pair<int, Real>
-    //                 jv = best_response_col(
-    //                     max_depth,
-    //                     device,
-    //                     state,
-    //                     model,
-    //                     matrix_node,
-    //                     min_val, beta,
-    //                     row_solution);
-
-    //             // prune this node if no best response is as good as alpha/beta
-    //             if (iv.first == -1)
-    //             {
-    //                 return {min_val, min_val};
-    //             }
-    //             if (jv.first == -1)
-    //             {
-    //                 return {max_val, max_val};
-    //             }
-
-    //             smaller_bounds = false;
-    //             new_action = false;
-    //             latest_row_idx = iv.first;
-    //             latest_col_idx = jv.first;
-
-    //             if (std::find(I.begin(), I.end(), latest_row_idx) == I.end())
-    //             {
-    //                 I.push_back(latest_row_idx);
-    //                 new_action = true;
-    //             }
-    //             if (std::find(J.begin(), J.end(), latest_col_idx) == J.end())
-    //             {
-    //                 J.push_back(latest_col_idx);
-    //                 new_action = true;
-    //             }
-    //             if (jv.second > alpha)
-    //             {
-    //                 alpha = jv.second;
-    //                 smaller_bounds = true;
-    //             }
-    //             if (iv.second < beta)
-    //             {
-    //                 beta = iv.second;
-    //                 smaller_bounds = true;
-    //             }
-    //         }
-
-    //         matrix_node->row_pricipal_idx = I[std::distance(row_solution.begin(), std::max_element(row_solution.begin(), row_solution.end()))];
-    //         matrix_node->col_pricipal_idx = J[std::distance(col_solution.begin(), std::max_element(col_solution.begin(), col_solution.end()))];
-
-    //         return {alpha, beta};
-    //     }
-
-    //     std::pair<int, Real>
-    //     best_response_row(
-    //         const size_t max_depth,
-    //         Types::PRNG &device,
-    //         const Types::State &state,
-    //         Types::Model &model,
-    //         MatrixNode *matrix_node,
-    //         Real alpha, Real beta,
-    //         Types::VectorReal &col_strategy) const
-    //     {
-    //         std::vector<int> &I = matrix_node->I;
-    //         std::vector<int> &J = matrix_node->J;
-    //         int best_row_idx = -1;
-
-    //         for (int row_idx = 0; row_idx < state.row_actions.size(); ++row_idx)
-    //         {
-    //             const auto row_action = state.row_actions[row_idx];
-
-    //             const bool skip_exploration = (std::find(I.begin(), I.end(), row_idx) != I.end());
-
-    //             // 'priority' is the product of the opposing and 'chance' players probability
-    //             // its clearly what we want to minimize rather than just the chance component
-    //             Real max_priority{0}, expected_value{0}, total_unexplored{0};
-    //             std::vector<Real> exploration_priorities{};
-    //             int col_idx, next_j;
-    //             for (int j = 0; j < J.size(); ++j)
-    //             {
-    //                 const int col_idx_temp = J[j];
-    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx_temp);
-    //                 // we still have to calculate expected score to return -1 if pruning is called for
-    //                 expected_value += col_strategy[j] * data.beta_explored;
-
-    //                 const Real priority =
-    //                     (skip_exploration || (data.tries >= max_tries))
-    //                         ? Real{0}
-    //                         : Real{col_strategy[j] * data.unexplored};
-    //                 total_unexplored += priority;
-    //                 exploration_priorities.push_back(priority);
-    //                 if (priority > max_priority)
-    //                 {
-    //                     col_idx = col_idx_temp;
-    //                     max_priority = priority;
-    //                     next_j = j;
-    //                 }
-    //             }
-
-    //             while (
-    //                 (max_priority > Real{0}) &&
-    //                 (Real{expected_value + beta * total_unexplored} >= alpha))
-    //             {
-    //                 const auto col_action = state.col_actions[col_idx];
-
-    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-
-    //                 bool produced_new_branch = false;
-    //                 for (; data.tries < max_tries; ++data.tries)
-    //                 {
-    //                     typename Types::State state_copy{state};
-    //                     const typename Types::Seed seed{device.uniform_64()};
-    //                     state_copy.randomize_transition(seed);
-    //                     state_copy.apply_actions(row_action, col_action);
-    //                     const size_t obs_hash = hasher(state_copy.get_obs());
-
-    //                     if (data.branches.find(obs_hash) == data.branches.end())
-    //                     {
-    //                         produced_new_branch = true;
-    //                         // data.branches.emplace(obs_hash, state_copy, seed);
-
-    //                         Branch new_branch{state_copy, seed};
-
-    //                         new_branch.matrix_node->depth = matrix_node->depth + 1;
-    //                         const auto prob = new_branch.prob;
-
-    //                         auto alpha_beta_pair = double_oracle(
-    //                             max_depth,
-    //                             device,
-    //                             state_copy,
-    //                             model,
-    //                             new_branch.matrix_node.get(),
-    //                             min_val, max_val);
-
-    //                         data.alpha_explored += alpha_beta_pair.first * prob;
-    //                         data.beta_explored += alpha_beta_pair.second * prob;
-    //                         expected_value += alpha_beta_pair.second * prob * col_strategy[next_j];
-
-    //                         data.unexplored -= prob;
-    //                         total_unexplored -= prob * col_strategy[next_j];
-    //                         exploration_priorities[next_j] -= prob * col_strategy[next_j];
-
-    //                         break;
-    //                     }
-    //                 }
-
-    //                 if (!produced_new_branch)
-    //                 {
-    //                     exploration_priorities[next_j] = typename Types::Q{0};
-    //                 }
-
-    //                 max_priority = typename Types::Q{0};
-    //                 for (int j = 0; j < J.size(); ++j)
-    //                 {
-    //                     const Real priority = exploration_priorities[j];
-    //                     if (priority > max_priority)
-    //                     {
-    //                         col_idx = J[j];
-    //                         max_priority = priority;
-    //                         next_j = j;
-    //                     }
-    //                 }
-    //             }
-
-    //             if (expected_value >= alpha || (best_row_idx == -1 && fuzzy_equals(expected_value, alpha)))
-    //             {
-    //                 best_row_idx = row_idx;
-    //                 alpha = expected_value;
-    //             }
-    //         }
-    //         return {best_row_idx, alpha};
-    //     }
-
-    //     std::pair<int, Real>
-    //     best_response_col(
-    //         const size_t max_depth,
-    //         Types::PRNG &device,
-    //         const Types::State &state,
-    //         Types::Model &model,
-    //         MatrixNode *matrix_node,
-    //         Real alpha, Real beta,
-    //         Types::VectorReal &row_strategy) const
-    //     {
-    //         std::vector<int> &I = matrix_node->I;
-    //         std::vector<int> &J = matrix_node->J;
-    //         int best_col_idx = -1;
-
-    //         for (int col_idx = 0; col_idx < state.col_actions.size(); ++col_idx)
-    //         {
-    //             const auto col_action = state.col_actions[col_idx];
-
-    //             const bool skip_exploration = (std::find(J.begin(), J.end(), col_idx) != J.end());
-
-    //             // 'priority' is the product of the opposing and 'chance' players probability
-    //             // its clearly what we want to minimize rather than just the chance component
-    //             Real max_priority{0}, expected_value{0}, total_unexplored{0};
-    //             std::vector<Real> exploration_priorities{};
-    //             int row_idx, next_i;
-    //             for (int i = 0; i < I.size(); ++i)
-    //             {
-    //                 const int row_idx_temp = I[i];
-    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx_temp, col_idx);
-    //                 // we still have to calculate expected score to return -1 if pruning is called for
-    //                 expected_value += row_strategy[i] * data.alpha_explored;
-
-    //                 const Real priority =
-    //                     (skip_exploration || (data.tries >= max_tries))
-    //                         ? Real{0}
-    //                         : Real{row_strategy[i] * data.unexplored};
-
-    //                 total_unexplored += priority;
-    //                 exploration_priorities.push_back(priority);
-    //                 if (priority > max_priority)
-    //                 {
-    //                     row_idx = row_idx_temp;
-    //                     max_priority = priority;
-    //                     next_i = i;
-    //                 }
-    //             }
-
-    //             while (
-    //                 (max_priority > Real{0}) &&
-    //                 (Real{expected_value + alpha * total_unexplored} <= beta))
-    //             {
-    //                 const auto row_action = state.row_actions[row_idx];
-
-    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-
-    //                 bool produced_new_branch = false;
-    //                 for (; data.tries < max_tries; ++data.tries)
-    //                 {
-    //                     typename Types::State state_copy{state};
-    //                     const typename Types::Seed seed{device.uniform_64()};
-    //                     state_copy.randomize_transition(seed);
-    //                     state_copy.apply_actions(row_action, col_action);
-    //                     const size_t obs_hash = hasher(state_copy.get_obs());
-
-    //                     if (data.branches.find(obs_hash) == data.branches.end())
-    //                     {
-    //                         produced_new_branch = true;
-    //                         // Branch &new_branch = (*(data.branches.emplace(obs_hash, state_copy, seed).first)).second;
-    //                         Branch new_branch{state_copy, seed};
-
-    //                         new_branch.matrix_node->depth = matrix_node->depth + 1;
-    //                         const auto prob = new_branch.prob;
-
-    //                         auto alpha_beta_pair = double_oracle(
-    //                             max_depth,
-    //                             device,
-    //                             state_copy,
-    //                             model,
-    //                             new_branch.matrix_node.get(),
-    //                             min_val, max_val); // TODO alpha/beta
-
-    //                         data.alpha_explored += alpha_beta_pair.first * prob;
-    //                         data.beta_explored += alpha_beta_pair.second * prob;
-    //                         expected_value += alpha_beta_pair.first * prob * row_strategy[next_i];
-
-    //                         data.unexplored -= prob;
-    //                         total_unexplored -= prob * row_strategy[next_i];
-    //                         exploration_priorities[next_i] -= prob * row_strategy[next_i];
-
-    //                         break;
-    //                     }
-    //                 }
-
-    //                 if (!produced_new_branch)
-    //                 {
-    //                     exploration_priorities[next_i] = typename Types::Q{0};
-    //                 }
-
-    //                 max_priority = typename Types::Q{0};
-    //                 for (int i = 0; i < I.size(); ++i)
-    //                 {
-    //                     const Real priority = exploration_priorities[i];
-    //                     if (priority > max_priority)
-    //                     {
-    //                         row_idx = I[i];
-    //                         max_priority = priority;
-    //                         next_i = i;
-    //                     }
-    //                 }
-    //             }
-
-    //             if (expected_value <= beta || (best_col_idx == -1 && fuzzy_equals(expected_value, beta)))
-    //             {
-    //                 best_col_idx = col_idx;
-    //                 beta = expected_value;
-    //             }
-    //         }
-    //         return {best_col_idx, beta};
-    //     }
-
-    // private:
-    //     template <template <typename> typename Wrapper, typename T>
-    //     inline bool fuzzy_equals(Wrapper<T> x, Wrapper<T> y) const
-    //     {
-    //         if constexpr (std::is_same_v<T, mpq_class>)
-    //         {
-    //             mpq_ptr a = x.value.get_mpq_t();
-    //             mpq_ptr b = y.value.get_mpq_t();
-    //             mpq_canonicalize(a);
-    //             mpq_canonicalize(b);
-    //             bool answer = mpq_equal(a, b);
-    //             return answer;
-    //         }
-    //         else
-    //         {
-    //             static const Real epsilon{Rational{1, 1 << 24}};
-    //             static const Real neg_epsilon{Rational{-1, 1 << 24}};
-    //             Wrapper<T> z{x - y};
-    //             return neg_epsilon < z && z < epsilon;
-    //         }
-    //     }
-
-    //     template <template <typename> typename Wrapper, typename T>
-    //     inline bool fuzzy_greater(Wrapper<T> x, Wrapper<T> y) const
-    //     {
-    //         if constexpr (std::is_same_v<T, mpq_class>)
-    //         {
-    //             return x > y;
-    //         }
-    //         else
-    //         {
-    //             static const Real epsilon{Rational{1, 1 << 24}};
-    //             bool a = x > y + epsilon;
-    //             return a;
-    //         }
-    //     }
-
-    //     inline bool try_solve_chance_branches(
-    //         const size_t max_depth,
-    //         Types::PRNG &device,
-    //         const Types::State &state,
-    //         Types::Model &model,
-    //         MatrixNode *matrix_node,
-    //         int row_idx, int col_idx) const
-    //     {
-    //         Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-
-    //         const auto row_action = state.row_actions[row_idx];
-    //         const auto col_action = state.col_actions[col_idx];
-
-    //         for (; data.tries < max_tries && data.unexplored > typename Types::Prob{0}; ++data.tries)
-    //         {
-    //             typename Types::State state_copy{state};
-    //             const typename Types::Seed seed{device.uniform_64()};
-    //             state_copy.randomize_transition(seed);
-    //             state_copy.apply_actions(row_action, col_action);
-    //             const size_t obs_hash = hasher(state_copy.get_obs());
-
-    //             if (data.branches.find(obs_hash) == data.branches.end())
-    //             {
-    //                 // Branch &new_branch = (*(data.branches.emplace(obs_hash, state_copy, seed).first)).second;
-    //                 Branch new_branch{state_copy, seed};
-
-    //                 new_branch.matrix_node->depth = matrix_node->depth + 1;
-
-    //                 const auto alpha_beta =
-    //                     double_oracle(
-    //                         max_depth,
-    //                         device,
-    //                         state_copy,
-    //                         model,
-    //                         new_branch.matrix_node.get(),
-    //                         min_val, max_val);
-
-    //                 data.alpha_explored += alpha_beta.first * new_branch.prob;
-    //                 data.beta_explored += alpha_beta.second * new_branch.prob;
-    //                 data.unexplored -= new_branch.prob;
-    //             }
-    //         }
-
-    //         const bool solved_exactly = (data.alpha_explored == data.beta_explored) && (data.unexplored == Real{Rational<>{0}});
-    //         return solved_exactly;
-    //     };
-
-    //     Real row_alpha_beta(
-    //         Types::State &state,
-    //         Types::Model &model,
-    //         MatrixNode *matrix_node,
-    //         Real alpha,
-    //         Real beta)
-    //     {
-    //         return max_val;
-    //     }
-
-    //     Real col_alpha_beta(
-    //         Types::State &state,
-    //         Types::Model &model,
-    //         MatrixNode *matrix_node,
-    //         Real alpha,
-    //         Real beta)
-    //     {
-    //         return min_val;
-    //     }
-    //     // Serialized AlphaBeta, TODO
-
-    //     static bool dont_terminate(
-    //         Types::PRNG &,
-    //         const Data &)
-    //     {
-    //         return false;
-    //     };
-
-    //     static bool after_some_time(
-    //         Types::PRNG &device,
-    //         const Data &data)
-    //     {
-    //         const typename Types::Prob x{Rational<>{1, 4}};
-    //         return (data.next_chance_idx > 1 &&
-    //                 data.unexplored < x);
-    //     }
-
-    //     static bool thing(
-    //         Types::PRNG &device,
-    //         const Data &data)
-    //     {
-    //         // return (data.unexplored + (1 / 2) > )
-    //         return false;
-    //     }
+        std::pair<Real, Real>
+        double_oracle(
+            const size_t max_depth,
+            Types::PRNG &device,
+            Types::State &state,
+            Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha,
+            Real beta) const
+        {
+            if (state.is_terminal())
+            {
+                const typename Types::Value payoff = state.get_payoff();
+                matrix_node->alpha = payoff.get_row_value();
+                matrix_node->beta = payoff.get_row_value();
+                return {payoff.get_row_value(), payoff.get_row_value()};
+            }
+
+            if (matrix_node->depth >= max_depth)
+            {
+                typename Types::ModelOutput model_output;
+                model.inference(std::move(state), model_output);
+                matrix_node->alpha = model_output.value.get_row_value();
+                matrix_node->beta = model_output.value.get_row_value();
+                return {model_output.value.get_row_value(), model_output.value.get_row_value()};
+            }
+
+            state.get_actions();
+            const size_t rows = state.row_actions.size();
+            const size_t cols = state.col_actions.size();
+
+            DataMatrix<Data> &data_matrix = matrix_node->chance_data_matrix;
+            if (data_matrix.size() == 0)
+            {
+                data_matrix.rows = rows;
+                data_matrix.cols = cols;
+                for (int i = 0; i < rows * cols; ++i)
+                {
+                    data_matrix.emplace_back();
+                }
+            }
+
+            std::vector<int> &I = matrix_node->I;
+            std::vector<int> &J = matrix_node->J;
+            // current best strategy. used to calculate best response values
+            // entries correspond to I, J entires and order. It is a permuted submatrix of the full matrix, basically.
+            typename Types::VectorReal &row_solution = matrix_node->row_solution;
+            typename Types::VectorReal &col_solution = matrix_node->col_solution;
+
+            // I,J are the only places we can use prior solve info
+            // either already there or init to 0
+            I.push_back(matrix_node->row_pricipal_idx);
+            J.push_back(matrix_node->col_pricipal_idx);
+
+            bool smaller_bounds = false;
+            bool new_action = true;
+            int latest_row_idx = matrix_node->row_pricipal_idx;
+            int latest_col_idx = matrix_node->col_pricipal_idx;
+            bool solved_exactly = true;
+
+            while (!fuzzy_equals(alpha, beta) && (smaller_bounds || new_action))
+            {
+
+                // get entry values/bounds for newly expanded sub game, use last added actions
+
+                for (const int row_idx : I)
+                {
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx, latest_col_idx);
+                    solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, row_idx, latest_col_idx);
+                }
+
+                for (const int col_idx : J)
+                {
+                    Data &data = matrix_node->chance_data_matrix.get(latest_row_idx, col_idx);
+                    solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, latest_row_idx, col_idx);
+                }
+
+                // solve newly expanded and explored game
+
+                int entry_idx = 0;
+                if (solved_exactly)
+                {
+                    typename Types::MatrixValue matrix{I.size(), J.size()};
+                    for (auto row_idx : I)
+                    {
+                        for (auto col_idx : J)
+                        {
+                            const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+                            matrix[entry_idx] = data.alpha_explored;
+                            ++entry_idx;
+                        }
+                    }
+                    LRSNash::solve(matrix, row_solution, col_solution);
+                }
+                else
+                {
+                    typename Types::MatrixValue alpha_matrix{I.size(), J.size()}, beta_matrix{I.size(), J.size()};
+                    for (auto row_idx : I)
+                    {
+                        for (auto col_idx : J)
+                        {
+                            const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+                            alpha_matrix[entry_idx] = static_cast<Real>(data.alpha_explored + data.unexplored * min_val);
+                            beta_matrix[entry_idx] = static_cast<Real>(data.beta_explored + data.unexplored * max_val);
+                            ++entry_idx;
+                        }
+                    }
+                    typename Types::VectorReal temp;
+                    LRSNash::solve(alpha_matrix, row_solution, temp);
+                    temp.clear();
+                    LRSNash::solve(beta_matrix, temp, col_solution);
+                }
+
+                std::pair<int, Real>
+                    iv =
+                        best_response_row(
+                            max_depth,
+                            device,
+                            state,
+                            model,
+                            matrix_node,
+                            alpha, max_val,
+                            col_solution);
+
+                std::pair<int, Real>
+                    jv =
+                        best_response_col(
+                            max_depth,
+                            device,
+                            state,
+                            model,
+                            matrix_node,
+                            min_val, beta,
+                            row_solution);
+
+                // prune this node if no best response is as good as alpha/beta
+                if (iv.first == -1)
+                {
+                    return {min_val, min_val};
+                }
+                if (jv.first == -1)
+                {
+                    return {max_val, max_val};
+                }
+
+                smaller_bounds = false;
+                new_action = false;
+                latest_row_idx = iv.first;
+                latest_col_idx = jv.first;
+
+                if (std::find(I.begin(), I.end(), latest_row_idx) == I.end())
+                {
+                    I.push_back(latest_row_idx);
+                    new_action = true;
+                }
+                if (std::find(J.begin(), J.end(), latest_col_idx) == J.end())
+                {
+                    J.push_back(latest_col_idx);
+                    new_action = true;
+                }
+                if (jv.second > alpha)
+                {
+                    alpha = jv.second;
+                    smaller_bounds = true;
+                }
+                if (iv.second < beta)
+                {
+                    beta = iv.second;
+                    smaller_bounds = true;
+                }
+            }
+
+            matrix_node->row_pricipal_idx = I[std::distance(row_solution.begin(), std::max_element(row_solution.begin(), row_solution.end()))];
+            matrix_node->col_pricipal_idx = J[std::distance(col_solution.begin(), std::max_element(col_solution.begin(), col_solution.end()))];
+
+            return {alpha, beta};
+        }
+
+        std::pair<int, Real>
+        best_response_row(
+            const size_t max_depth,
+            Types::PRNG &device,
+            const Types::State &state,
+            Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha, Real beta,
+            Types::VectorReal &col_strategy) const
+        {
+            std::vector<int> &I = matrix_node->I;
+            std::vector<int> &J = matrix_node->J;
+            int best_row_idx = -1;
+
+            for (int row_idx = 0; row_idx < state.row_actions.size(); ++row_idx)
+            {
+                const auto row_action = state.row_actions[row_idx];
+
+                const bool skip_exploration = (std::find(I.begin(), I.end(), row_idx) != I.end());
+
+                // 'priority' is the product of the opposing and 'chance' players probability
+                // its clearly what we want to minimize rather than just the chance component
+                Real max_priority{0}, expected_value{0}, total_unexplored{0};
+                std::vector<Real> exploration_priorities{};
+                int col_idx, next_j;
+                for (int j = 0; j < J.size(); ++j)
+                {
+                    const int col_idx_temp = J[j];
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx_temp);
+                    // we still have to calculate expected score to return -1 if pruning is called for
+                    expected_value += col_strategy[j] * data.beta_explored;
+
+                    const Real priority =
+                        (skip_exploration || (data.tries >= max_tries))
+                            ? Real{0}
+                            : Real{col_strategy[j] * data.unexplored};
+                    total_unexplored += priority;
+                    exploration_priorities.push_back(priority);
+                    if (priority > max_priority)
+                    {
+                        col_idx = col_idx_temp;
+                        max_priority = priority;
+                        next_j = j;
+                    }
+                }
+
+                while (
+                    (max_priority > Real{0}) &&
+                    (Real{expected_value + beta * total_unexplored} >= alpha))
+                {
+                    const auto col_action = state.col_actions[col_idx];
+
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+
+                    bool produced_new_branch = false;
+                    for (; data.tries < max_tries; ++data.tries)
+                    {
+                        typename Types::State state_copy{state};
+                        const typename Types::Seed seed{device.uniform_64()};
+                        state_copy.randomize_transition(seed);
+                        state_copy.apply_actions(row_action, col_action);
+                        const size_t obs_hash = hasher(state_copy.get_obs());
+
+                        if (data.branches.find(obs_hash) == data.branches.end())
+                        {
+                            produced_new_branch = true;
+
+                            data.branches.emplace(
+                                std::piecewise_construct,
+                                std::forward_as_tuple(obs_hash),
+                                std::forward_as_tuple(state_copy, seed));
+                            Branch &new_branch = data.branches.at(obs_hash);
+
+                            new_branch.matrix_node->depth = matrix_node->depth + 1;
+                            const auto prob = new_branch.prob;
+
+                            auto alpha_beta_pair = double_oracle(
+                                max_depth,
+                                device,
+                                state_copy,
+                                model,
+                                new_branch.matrix_node.get(),
+                                min_val, max_val);
+
+                            data.alpha_explored += alpha_beta_pair.first * prob;
+                            data.beta_explored += alpha_beta_pair.second * prob;
+                            expected_value += alpha_beta_pair.second * prob * col_strategy[next_j];
+
+                            data.unexplored -= prob;
+                            total_unexplored -= prob * col_strategy[next_j];
+                            exploration_priorities[next_j] -= prob * col_strategy[next_j];
+
+                            break;
+                        }
+                    }
+
+                    if (!produced_new_branch)
+                    {
+                        exploration_priorities[next_j] = typename Types::Q{0};
+                    }
+
+                    max_priority = typename Types::Q{0};
+                    for (int j = 0; j < J.size(); ++j)
+                    {
+                        const Real priority = exploration_priorities[j];
+                        if (priority > max_priority)
+                        {
+                            col_idx = J[j];
+                            max_priority = priority;
+                            next_j = j;
+                        }
+                    }
+                }
+
+                if (expected_value >= alpha || (best_row_idx == -1 && fuzzy_equals(expected_value, alpha)))
+                {
+                    best_row_idx = row_idx;
+                    alpha = expected_value;
+                }
+            }
+            return {best_row_idx, alpha};
+        }
+
+        std::pair<int, Real>
+        best_response_col(
+            const size_t max_depth,
+            Types::PRNG &device,
+            const Types::State &state,
+            Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha, Real beta,
+            Types::VectorReal &row_strategy) const
+        {
+            std::vector<int> &I = matrix_node->I;
+            std::vector<int> &J = matrix_node->J;
+            int best_col_idx = -1;
+
+            for (int col_idx = 0; col_idx < state.col_actions.size(); ++col_idx)
+            {
+                const auto col_action = state.col_actions[col_idx];
+
+                const bool skip_exploration = (std::find(J.begin(), J.end(), col_idx) != J.end());
+
+                // 'priority' is the product of the opposing and 'chance' players probability
+                // its clearly what we want to minimize rather than just the chance component
+                Real max_priority{0}, expected_value{0}, total_unexplored{0};
+                std::vector<Real> exploration_priorities{};
+                int row_idx, next_i;
+                for (int i = 0; i < I.size(); ++i)
+                {
+                    const int row_idx_temp = I[i];
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx_temp, col_idx);
+                    // we still have to calculate expected score to return -1 if pruning is called for
+                    expected_value += row_strategy[i] * data.alpha_explored;
+
+                    const Real priority =
+                        (skip_exploration || (data.tries >= max_tries))
+                            ? Real{0}
+                            : Real{row_strategy[i] * data.unexplored};
+
+                    total_unexplored += priority;
+                    exploration_priorities.push_back(priority);
+                    if (priority > max_priority)
+                    {
+                        row_idx = row_idx_temp;
+                        max_priority = priority;
+                        next_i = i;
+                    }
+                }
+
+                while (
+                    (max_priority > Real{0}) &&
+                    (Real{expected_value + alpha * total_unexplored} <= beta))
+                {
+                    const auto row_action = state.row_actions[row_idx];
+
+                    Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+
+                    bool produced_new_branch = false;
+                    for (; data.tries < max_tries; ++data.tries)
+                    {
+                        typename Types::State state_copy{state};
+                        const typename Types::Seed seed{device.uniform_64()};
+                        state_copy.randomize_transition(seed);
+                        state_copy.apply_actions(row_action, col_action);
+                        const size_t obs_hash = hasher(state_copy.get_obs());
+
+                        if (data.branches.find(obs_hash) == data.branches.end())
+                        {
+                            produced_new_branch = true;
+
+                            data.branches.emplace(
+                                std::piecewise_construct,
+                                std::forward_as_tuple(obs_hash),
+                                std::forward_as_tuple(state_copy, seed));
+                            Branch &new_branch = data.branches.at(obs_hash);
+
+                            new_branch.matrix_node->depth = matrix_node->depth + 1;
+                            const auto prob = new_branch.prob;
+
+                            auto alpha_beta_pair = double_oracle(
+                                max_depth,
+                                device,
+                                state_copy,
+                                model,
+                                new_branch.matrix_node.get(),
+                                min_val, max_val); // TODO alpha/beta
+
+                            data.alpha_explored += alpha_beta_pair.first * prob;
+                            data.beta_explored += alpha_beta_pair.second * prob;
+                            expected_value += alpha_beta_pair.first * prob * row_strategy[next_i];
+
+                            data.unexplored -= prob;
+                            total_unexplored -= prob * row_strategy[next_i];
+                            exploration_priorities[next_i] -= prob * row_strategy[next_i];
+
+                            break;
+                        }
+                    }
+
+                    if (!produced_new_branch)
+                    {
+                        exploration_priorities[next_i] = typename Types::Q{0};
+                    }
+
+                    max_priority = typename Types::Q{0};
+                    for (int i = 0; i < I.size(); ++i)
+                    {
+                        const Real priority = exploration_priorities[i];
+                        if (priority > max_priority)
+                        {
+                            row_idx = I[i];
+                            max_priority = priority;
+                            next_i = i;
+                        }
+                    }
+                }
+
+                if (expected_value <= beta || (best_col_idx == -1 && fuzzy_equals(expected_value, beta)))
+                {
+                    best_col_idx = col_idx;
+                    beta = expected_value;
+                }
+            }
+            return {best_col_idx, beta};
+        }
+
+    private:
+        template <template <typename> typename Wrapper, typename T>
+        inline bool fuzzy_equals(Wrapper<T> x, Wrapper<T> y) const
+        {
+            if constexpr (std::is_same_v<T, mpq_class>)
+            {
+                mpq_ptr a = x.value.get_mpq_t();
+                mpq_ptr b = y.value.get_mpq_t();
+                mpq_canonicalize(a);
+                mpq_canonicalize(b);
+                bool answer = mpq_equal(a, b);
+                return answer;
+            }
+            else
+            {
+                static const Real epsilon{Rational{1, 1 << 24}};
+                static const Real neg_epsilon{Rational{-1, 1 << 24}};
+                Wrapper<T> z{x - y};
+                return neg_epsilon < z && z < epsilon;
+            }
+        }
+
+        template <template <typename> typename Wrapper, typename T>
+        inline bool fuzzy_greater(Wrapper<T> x, Wrapper<T> y) const
+        {
+            if constexpr (std::is_same_v<T, mpq_class>)
+            {
+                return x > y;
+            }
+            else
+            {
+                static const Real epsilon{Rational{1, 1 << 24}};
+                bool a = x > y + epsilon;
+                return a;
+            }
+        }
+
+        inline bool try_solve_chance_branches(
+            const size_t max_depth,
+            Types::PRNG &device,
+            const Types::State &state,
+            Types::Model &model,
+            MatrixNode *matrix_node,
+            int row_idx, int col_idx) const
+        {
+            Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+
+            const auto row_action = state.row_actions[row_idx];
+            const auto col_action = state.col_actions[col_idx];
+
+            for (; data.tries < max_tries && data.unexplored > typename Types::Prob{0}; ++data.tries)
+            {
+                typename Types::State state_copy{state};
+                const typename Types::Seed seed{device.uniform_64()};
+                state_copy.randomize_transition(seed);
+                state_copy.apply_actions(row_action, col_action);
+                const size_t obs_hash = hasher(state_copy.get_obs());
+
+                if (data.branches.find(obs_hash) == data.branches.end())
+                {
+                    data.branches.emplace(
+                        std::piecewise_construct,
+                        std::forward_as_tuple(obs_hash),
+                        std::forward_as_tuple(state_copy, seed));
+                    Branch &new_branch = data.branches.at(obs_hash);
+
+                    new_branch.matrix_node->depth = matrix_node->depth + 1;
+
+                    const auto alpha_beta =
+                        double_oracle(
+                            max_depth,
+                            device,
+                            state_copy,
+                            model,
+                            new_branch.matrix_node.get(),
+                            min_val, max_val);
+
+                    data.alpha_explored += alpha_beta.first * new_branch.prob;
+                    data.beta_explored += alpha_beta.second * new_branch.prob;
+                    data.unexplored -= new_branch.prob;
+                }
+            }
+
+            const bool solved_exactly = (data.alpha_explored == data.beta_explored) && (data.unexplored == Real{Rational<>{0}});
+            return solved_exactly;
+        };
+
+        Real row_alpha_beta(
+            Types::State &state,
+            Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha,
+            Real beta)
+        {
+            return max_val;
+        }
+
+        Real col_alpha_beta(
+            Types::State &state,
+            Types::Model &model,
+            MatrixNode *matrix_node,
+            Real alpha,
+            Real beta)
+        {
+            return min_val;
+        }
+        // Serialized AlphaBeta, TODO
+
+        static bool dont_terminate(
+            Types::PRNG &,
+            const Data &)
+        {
+            return false;
+        };
+
+        static bool after_some_time(
+            Types::PRNG &device,
+            const Data &data)
+        {
+            const typename Types::Prob x{Rational<>{1, 4}};
+            return (data.next_chance_idx > 1 &&
+                    data.unexplored < x);
+        }
+
+        static bool thing(
+            Types::PRNG &device,
+            const Data &data)
+        {
+            // return (data.unexplored + (1 / 2) > )
+            return false;
+        }
     };
 };

--- a/src/algorithm/solver/alpha-beta-force.hh
+++ b/src/algorithm/solver/alpha-beta-force.hh
@@ -21,26 +21,30 @@ struct AlphaBetaForce : Types
         typename Types::Seed seed;
         std::unique_ptr<MatrixNode> matrix_node;
 
-        Branch(const Branch &) = delete;
-        Branch &operator=(const Branch &) = delete;
+        // Branch(const Branch &) = delete;
+        // Branch &operator=(const Branch &) = delete;
 
         Branch(
             const Types::State &state,
-            const Types::Seed seed)
-            : prob{state.prob}, obs{state.get_obs()}, seed{seed}, matrix_node{std::make_unique<MatrixNode>()} {}
+            const Types::Seed &seed)
+            // : prob{state.prob}, obs{state.get_obs()}, seed{seed}
+            // matrix_node{std::make_unique<MatrixNode>()} 
+            {}
+    
+        Branch(const Types::State &state) {}
     };
 
     struct Data
     {
-        Types::Prob unexplored{1};
-        typename Types::Real alpha_explored{0}, beta_explored{0};
-        // int next_chance_idx = 0;
-        size_t tries = 0;
-        friend std::ostream &operator<<(std::ostream &os, const Data &data)
-        {
-            os << '(' << data.alpha_explored << " " << data.beta_explored << " " << data.unexplored << ")";
-            return os;
-        }
+        // Types::Prob unexplored{1};
+        // typename Types::Real alpha_explored{0}, beta_explored{0};
+        // // int next_chance_idx = 0;
+        // size_t tries = 0;
+        // friend std::ostream &operator<<(std::ostream &os, const Data &data)
+        // {
+        //     os << '(' << data.alpha_explored << " " << data.beta_explored << " " << data.unexplored << ")";
+        //     return os;
+        // }
 
         std::unordered_map<
             size_t,
@@ -50,13 +54,13 @@ struct AlphaBetaForce : Types
     struct MatrixNode
     {
         DataMatrix<Data> chance_data_matrix{};
-        Types::VectorReal row_solution{}, col_solution{};
-        unsigned int depth = 0;
+        // Types::VectorReal row_solution{}, col_solution{};
+        // unsigned int depth = 0;
 
-        int row_pricipal_idx = 0, col_pricipal_idx = 0;
-        std::vector<int> I{}, J{};
+        // int row_pricipal_idx = 0, col_pricipal_idx = 0;
+        // std::vector<int> I{}, J{};
 
-        typename Types::Real alpha, beta;
+        // typename Types::Real alpha, beta;
     };
 
     class Search
@@ -66,7 +70,7 @@ struct AlphaBetaForce : Types
 
         const Real min_val{0}; // don't need to use the Game values if you happen to know that State's
         const Real max_val{1};
-        bool (*const terminate)(typename Types::PRNG &, const Data &) = &dont_terminate;
+        // bool (*const terminate)(typename Types::PRNG &, const Data &) = &dont_terminate;
 
         const size_t max_tries = (1 << 12);
         const typename Types::ObsHash hasher{};
@@ -75,9 +79,9 @@ struct AlphaBetaForce : Types
 
         Search(Real min_val, Real max_val) : min_val(min_val), max_val(max_val) {}
 
-        Search(
-            Real min_val, Real max_val,
-            bool (*const terminate)(typename Types::PRNG &, const Data &)) : min_val(min_val), max_val(max_val), terminate{terminate} {}
+        // Search(
+        //     Real min_val, Real max_val,
+        //     bool (*const terminate)(typename Types::PRNG &, const Data &)) : min_val(min_val), max_val(max_val), terminate{terminate} {}
 
         auto run(
             const size_t max_depth, // let it overflow to super big number
@@ -87,544 +91,548 @@ struct AlphaBetaForce : Types
             MatrixNode &root) const
         {
             typename Types::State state_copy{state};
-            return double_oracle(max_depth, device, state_copy, model, &root, min_val, max_val);
+            root.chance_data_matrix.fill(1, 1);
+            Data &data = root.chance_data_matrix[0];
+            std::unordered_map<size_t, Branch> &branches = data.branches;
+            branches.emplace(0, state_copy, 0);
+            // return double_oracle(max_depth, device, state_copy, model, &root, min_val, max_val);
         }
 
-        std::pair<Real, Real>
-        double_oracle(
-            const size_t max_depth,
-            Types::PRNG &device,
-            Types::State &state,
-            Types::Model &model,
-            MatrixNode *matrix_node,
-            Real alpha,
-            Real beta) const
-        {
-            if (state.is_terminal())
-            {
-                const typename Types::Value payoff = state.get_payoff();
-                matrix_node->alpha = payoff.get_row_value();
-                matrix_node->beta = payoff.get_row_value();
-                return {payoff.get_row_value(), payoff.get_row_value()};
-            }
-
-            if (matrix_node->depth >= max_depth)
-            {
-                typename Types::ModelOutput model_output;
-                model.inference(std::move(state), model_output);
-                matrix_node->alpha = model_output.value.get_row_value();
-                matrix_node->beta = model_output.value.get_row_value();
-                return {model_output.value.get_row_value(), model_output.value.get_row_value()};
-            }
-
-            state.get_actions();
-            const size_t rows = state.row_actions.size();
-            const size_t cols = state.col_actions.size();
-            // assumes double expand is ok (it is?)
-            // matrix_node->expand(rows, cols);
-            matrix_node->chance_data_matrix.fill(rows, cols);
-
-            std::vector<int> &I = matrix_node->I;
-            std::vector<int> &J = matrix_node->J;
-            // current best strategy. used to calculate best response values
-            // entries correspond to I, J entires and order. It is a permuted submatrix of the full matrix, basically.
-            typename Types::VectorReal &row_solution = matrix_node->row_solution;
-            typename Types::VectorReal &col_solution = matrix_node->col_solution;
-
-            // I,J are the only places we can use prior solve info
-            // either already there or init to 0
-            I.push_back(matrix_node->row_pricipal_idx);
-            J.push_back(matrix_node->col_pricipal_idx);
-
-            bool smaller_bounds = false;
-            bool new_action = true;
-            int latest_row_idx = matrix_node->row_pricipal_idx;
-            int latest_col_idx = matrix_node->col_pricipal_idx;
-            bool solved_exactly = true;
-
-            while (!fuzzy_equals(alpha, beta) && (smaller_bounds || new_action))
-            {
-
-                // get entry values/bounds for newly expanded sub game, use last added actions
-
-                for (const int row_idx : I)
-                {
-                    Data &data = matrix_node->chance_data_matrix.get(row_idx, latest_col_idx);
-                    solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, row_idx, latest_col_idx);
-                }
-
-                for (const int col_idx : J)
-                {
-                    Data &data = matrix_node->chance_data_matrix.get(latest_row_idx, col_idx);
-                    solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, latest_row_idx, col_idx);
-                }
-
-                // solve newly expanded and explored game
-
-                int entry_idx = 0;
-                if (solved_exactly)
-                {
-                    typename Types::MatrixValue matrix{I.size(), J.size()};
-                    for (auto row_idx : I)
-                    {
-                        for (auto col_idx : J)
-                        {
-                            const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-                            matrix[entry_idx] = data.alpha_explored;
-                            ++entry_idx;
-                        }
-                    }
-                    LRSNash::solve(matrix, row_solution, col_solution);
-                }
-                else
-                {
-                    typename Types::MatrixValue alpha_matrix{I.size(), J.size()}, beta_matrix{I.size(), J.size()};
-                    for (auto row_idx : I)
-                    {
-                        for (auto col_idx : J)
-                        {
-                            const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-                            alpha_matrix[entry_idx] = static_cast<Real>(data.alpha_explored + data.unexplored * min_val);
-                            beta_matrix[entry_idx] = static_cast<Real>(data.beta_explored + data.unexplored * max_val);
-                            ++entry_idx;
-                        }
-                    }
-                    typename Types::VectorReal temp;
-                    LRSNash::solve(alpha_matrix, row_solution, temp);
-                    temp.clear();
-                    LRSNash::solve(beta_matrix, temp, col_solution);
-                }
-
-                std::pair<int, Real>
-                    iv = best_response_row(
-                        max_depth,
-                        device,
-                        state,
-                        model,
-                        matrix_node,
-                        alpha, max_val,
-                        col_solution);
-
-                std::pair<int, Real>
-                    jv = best_response_col(
-                        max_depth,
-                        device,
-                        state,
-                        model,
-                        matrix_node,
-                        min_val, beta,
-                        row_solution);
-
-                // prune this node if no best response is as good as alpha/beta
-                if (iv.first == -1)
-                {
-                    return {min_val, min_val};
-                }
-                if (jv.first == -1)
-                {
-                    return {max_val, max_val};
-                }
-
-                smaller_bounds = false;
-                new_action = false;
-                latest_row_idx = iv.first;
-                latest_col_idx = jv.first;
-
-                if (std::find(I.begin(), I.end(), latest_row_idx) == I.end())
-                {
-                    I.push_back(latest_row_idx);
-                    new_action = true;
-                }
-                if (std::find(J.begin(), J.end(), latest_col_idx) == J.end())
-                {
-                    J.push_back(latest_col_idx);
-                    new_action = true;
-                }
-                if (jv.second > alpha)
-                {
-                    alpha = jv.second;
-                    smaller_bounds = true;
-                }
-                if (iv.second < beta)
-                {
-                    beta = iv.second;
-                    smaller_bounds = true;
-                }
-            }
-
-            matrix_node->row_pricipal_idx = I[std::distance(row_solution.begin(), std::max_element(row_solution.begin(), row_solution.end()))];
-            matrix_node->col_pricipal_idx = J[std::distance(col_solution.begin(), std::max_element(col_solution.begin(), col_solution.end()))];
-
-            return {alpha, beta};
-        }
-
-        std::pair<int, Real>
-        best_response_row(
-            const size_t max_depth,
-            Types::PRNG &device,
-            const Types::State &state,
-            Types::Model &model,
-            MatrixNode *matrix_node,
-            Real alpha, Real beta,
-            Types::VectorReal &col_strategy) const
-        {
-            std::vector<int> &I = matrix_node->I;
-            std::vector<int> &J = matrix_node->J;
-            int best_row_idx = -1;
-
-            for (int row_idx = 0; row_idx < state.row_actions.size(); ++row_idx)
-            {
-                const auto row_action = state.row_actions[row_idx];
-
-                const bool skip_exploration = (std::find(I.begin(), I.end(), row_idx) != I.end());
-
-                // 'priority' is the product of the opposing and 'chance' players probability
-                // its clearly what we want to minimize rather than just the chance component
-                Real max_priority{0}, expected_value{0}, total_unexplored{0};
-                std::vector<Real> exploration_priorities{};
-                int col_idx, next_j;
-                for (int j = 0; j < J.size(); ++j)
-                {
-                    const int col_idx_temp = J[j];
-                    Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx_temp);
-                    // we still have to calculate expected score to return -1 if pruning is called for
-                    expected_value += col_strategy[j] * data.beta_explored;
-
-                    const Real priority =
-                        (skip_exploration || (data.tries >= max_tries))
-                            ? Real{0}
-                            : Real{col_strategy[j] * data.unexplored};
-                    total_unexplored += priority;
-                    exploration_priorities.push_back(priority);
-                    if (priority > max_priority)
-                    {
-                        col_idx = col_idx_temp;
-                        max_priority = priority;
-                        next_j = j;
-                    }
-                }
-
-                while (
-                    (max_priority > Real{0}) &&
-                    (Real{expected_value + beta * total_unexplored} >= alpha))
-                {
-                    const auto col_action = state.col_actions[col_idx];
-
-                    Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-
-                    bool produced_new_branch = false;
-                    for (; data.tries < max_tries; ++data.tries)
-                    {
-                        typename Types::State state_copy{state};
-                        const typename Types::Seed seed{device.uniform_64()};
-                        state_copy.randomize_transition(seed);
-                        state_copy.apply_actions(row_action, col_action);
-                        const size_t obs_hash = hasher(state_copy.get_obs());
-
-                        if (data.branches.find(obs_hash) == data.branches.end())
-                        {
-                            produced_new_branch = true;
-                            // Branch &new_branch = (*(data.branches.emplace(obs_hash, state_copy, seed).first)).second;
-
-                            Branch new_branch{state_copy, seed};
-
-                            new_branch.matrix_node->depth = matrix_node->depth + 1;
-                            const auto prob = new_branch.prob;
-
-                            auto alpha_beta_pair = double_oracle(
-                                max_depth,
-                                device,
-                                state_copy,
-                                model,
-                                new_branch.matrix_node.get(),
-                                min_val, max_val);
-
-                            data.alpha_explored += alpha_beta_pair.first * prob;
-                            data.beta_explored += alpha_beta_pair.second * prob;
-                            expected_value += alpha_beta_pair.second * prob * col_strategy[next_j];
-
-                            data.unexplored -= prob;
-                            total_unexplored -= prob * col_strategy[next_j];
-                            exploration_priorities[next_j] -= prob * col_strategy[next_j];
-
-                            break;
-                        }
-                    }
-
-                    if (!produced_new_branch)
-                    {
-                        exploration_priorities[next_j] = typename Types::Q{0};
-                    }
-
-                    max_priority = typename Types::Q{0};
-                    for (int j = 0; j < J.size(); ++j)
-                    {
-                        const Real priority = exploration_priorities[j];
-                        if (priority > max_priority)
-                        {
-                            col_idx = J[j];
-                            max_priority = priority;
-                            next_j = j;
-                        }
-                    }
-                }
-
-                if (expected_value >= alpha || (best_row_idx == -1 && fuzzy_equals(expected_value, alpha)))
-                {
-                    best_row_idx = row_idx;
-                    alpha = expected_value;
-                }
-            }
-            return {best_row_idx, alpha};
-        }
-
-        std::pair<int, Real>
-        best_response_col(
-            const size_t max_depth,
-            Types::PRNG &device,
-            const Types::State &state,
-            Types::Model &model,
-            MatrixNode *matrix_node,
-            Real alpha, Real beta,
-            Types::VectorReal &row_strategy) const
-        {
-            std::vector<int> &I = matrix_node->I;
-            std::vector<int> &J = matrix_node->J;
-            int best_col_idx = -1;
-
-            for (int col_idx = 0; col_idx < state.col_actions.size(); ++col_idx)
-            {
-                const auto col_action = state.col_actions[col_idx];
-
-                const bool skip_exploration = (std::find(J.begin(), J.end(), col_idx) != J.end());
-
-                // 'priority' is the product of the opposing and 'chance' players probability
-                // its clearly what we want to minimize rather than just the chance component
-                Real max_priority{0}, expected_value{0}, total_unexplored{0};
-                std::vector<Real> exploration_priorities{};
-                int row_idx, next_i;
-                for (int i = 0; i < I.size(); ++i)
-                {
-                    const int row_idx_temp = I[i];
-                    Data &data = matrix_node->chance_data_matrix.get(row_idx_temp, col_idx);
-                    // we still have to calculate expected score to return -1 if pruning is called for
-                    expected_value += row_strategy[i] * data.alpha_explored;
-
-                    const Real priority =
-                        (skip_exploration || (data.tries >= max_tries))
-                            ? Real{0}
-                            : Real{row_strategy[i] * data.unexplored};
-
-                    total_unexplored += priority;
-                    exploration_priorities.push_back(priority);
-                    if (priority > max_priority)
-                    {
-                        row_idx = row_idx_temp;
-                        max_priority = priority;
-                        next_i = i;
-                    }
-                }
-
-                while (
-                    (max_priority > Real{0}) &&
-                    (Real{expected_value + alpha * total_unexplored} <= beta))
-                {
-                    const auto row_action = state.row_actions[row_idx];
-
-                    Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-
-                    bool produced_new_branch = false;
-                    for (; data.tries < max_tries; ++data.tries)
-                    {
-                        typename Types::State state_copy{state};
-                        const typename Types::Seed seed{device.uniform_64()};
-                        state_copy.randomize_transition(seed);
-                        state_copy.apply_actions(row_action, col_action);
-                        const size_t obs_hash = hasher(state_copy.get_obs());
-
-                        if (data.branches.find(obs_hash) == data.branches.end())
-                        {
-                            produced_new_branch = true;
-                            // Branch &new_branch = (*(data.branches.emplace(obs_hash, state_copy, seed).first)).second;
-                            Branch new_branch{state_copy, seed};
-
-                            new_branch.matrix_node->depth = matrix_node->depth + 1;
-                            const auto prob = new_branch.prob;
-
-                            auto alpha_beta_pair = double_oracle(
-                                max_depth,
-                                device,
-                                state_copy,
-                                model,
-                                new_branch.matrix_node.get(),
-                                min_val, max_val); // TODO alpha/beta
-
-                            data.alpha_explored += alpha_beta_pair.first * prob;
-                            data.beta_explored += alpha_beta_pair.second * prob;
-                            expected_value += alpha_beta_pair.first * prob * row_strategy[next_i];
-
-                            data.unexplored -= prob;
-                            total_unexplored -= prob * row_strategy[next_i];
-                            exploration_priorities[next_i] -= prob * row_strategy[next_i];
-
-                            break;
-                        }
-                    }
-
-                    if (!produced_new_branch)
-                    {
-                        exploration_priorities[next_i] = typename Types::Q{0};
-                    }
-
-                    max_priority = typename Types::Q{0};
-                    for (int i = 0; i < I.size(); ++i)
-                    {
-                        const Real priority = exploration_priorities[i];
-                        if (priority > max_priority)
-                        {
-                            row_idx = I[i];
-                            max_priority = priority;
-                            next_i = i;
-                        }
-                    }
-                }
-
-                if (expected_value <= beta || (best_col_idx == -1 && fuzzy_equals(expected_value, beta)))
-                {
-                    best_col_idx = col_idx;
-                    beta = expected_value;
-                }
-            }
-            return {best_col_idx, beta};
-        }
-
-    private:
-        template <template <typename> typename Wrapper, typename T>
-        inline bool fuzzy_equals(Wrapper<T> x, Wrapper<T> y) const
-        {
-            if constexpr (std::is_same_v<T, mpq_class>)
-            {
-                mpq_ptr a = x.value.get_mpq_t();
-                mpq_ptr b = y.value.get_mpq_t();
-                mpq_canonicalize(a);
-                mpq_canonicalize(b);
-                bool answer = mpq_equal(a, b);
-                return answer;
-            }
-            else
-            {
-                static const Real epsilon{Rational{1, 1 << 24}};
-                static const Real neg_epsilon{Rational{-1, 1 << 24}};
-                Wrapper<T> z{x - y};
-                return neg_epsilon < z && z < epsilon;
-            }
-        }
-
-        template <template <typename> typename Wrapper, typename T>
-        inline bool fuzzy_greater(Wrapper<T> x, Wrapper<T> y) const
-        {
-            if constexpr (std::is_same_v<T, mpq_class>)
-            {
-                return x > y;
-            }
-            else
-            {
-                static const Real epsilon{Rational{1, 1 << 24}};
-                bool a = x > y + epsilon;
-                return a;
-            }
-        }
-
-        inline bool try_solve_chance_branches(
-            const size_t max_depth,
-            Types::PRNG &device,
-            const Types::State &state,
-            Types::Model &model,
-            MatrixNode *matrix_node,
-            int row_idx, int col_idx) const
-        {
-            Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
-
-            const auto row_action = state.row_actions[row_idx];
-            const auto col_action = state.col_actions[col_idx];
-
-            for (; data.tries < max_tries && data.unexplored > typename Types::Prob{0}; ++data.tries)
-            {
-                typename Types::State state_copy{state};
-                const typename Types::Seed seed{device.uniform_64()};
-                state_copy.randomize_transition(seed);
-                state_copy.apply_actions(row_action, col_action);
-                const size_t obs_hash = hasher(state_copy.get_obs());
-
-                if (data.branches.find(obs_hash) == data.branches.end())
-                {
-                    // Branch &new_branch = (*(data.branches.emplace(obs_hash, state_copy, seed).first)).second;
-                    Branch new_branch{state_copy, seed};
-
-                    new_branch.matrix_node->depth = matrix_node->depth + 1;
-
-                    const auto alpha_beta =
-                        double_oracle(
-                            max_depth,
-                            device,
-                            state_copy,
-                            model,
-                            new_branch.matrix_node.get(),
-                            min_val, max_val);
-
-                    data.alpha_explored += alpha_beta.first * new_branch.prob;
-                    data.beta_explored += alpha_beta.second * new_branch.prob;
-                    data.unexplored -= new_branch.prob;
-                }
-            }
-
-            const bool solved_exactly = (data.alpha_explored == data.beta_explored) && (data.unexplored == Real{Rational<>{0}});
-            return solved_exactly;
-        };
-
-        Real row_alpha_beta(
-            Types::State &state,
-            Types::Model &model,
-            MatrixNode *matrix_node,
-            Real alpha,
-            Real beta)
-        {
-            return max_val;
-        }
-
-        Real col_alpha_beta(
-            Types::State &state,
-            Types::Model &model,
-            MatrixNode *matrix_node,
-            Real alpha,
-            Real beta)
-        {
-            return min_val;
-        }
-        // Serialized AlphaBeta, TODO
-
-        static bool dont_terminate(
-            Types::PRNG &,
-            const Data &)
-        {
-            return false;
-        };
-
-        static bool after_some_time(
-            Types::PRNG &device,
-            const Data &data)
-        {
-            const typename Types::Prob x{Rational<>{1, 4}};
-            return (data.next_chance_idx > 1 &&
-                    data.unexplored < x);
-        }
-
-        static bool thing(
-            Types::PRNG &device,
-            const Data &data)
-        {
-            // return (data.unexplored + (1 / 2) > )
-            return false;
-        }
+    //     std::pair<Real, Real>
+    //     double_oracle(
+    //         const size_t max_depth,
+    //         Types::PRNG &device,
+    //         Types::State &state,
+    //         Types::Model &model,
+    //         MatrixNode *matrix_node,
+    //         Real alpha,
+    //         Real beta) const
+    //     {
+    //         if (state.is_terminal())
+    //         {
+    //             const typename Types::Value payoff = state.get_payoff();
+    //             matrix_node->alpha = payoff.get_row_value();
+    //             matrix_node->beta = payoff.get_row_value();
+    //             return {payoff.get_row_value(), payoff.get_row_value()};
+    //         }
+
+    //         if (matrix_node->depth >= max_depth)
+    //         {
+    //             typename Types::ModelOutput model_output;
+    //             model.inference(std::move(state), model_output);
+    //             matrix_node->alpha = model_output.value.get_row_value();
+    //             matrix_node->beta = model_output.value.get_row_value();
+    //             return {model_output.value.get_row_value(), model_output.value.get_row_value()};
+    //         }
+
+    //         state.get_actions();
+    //         const size_t rows = state.row_actions.size();
+    //         const size_t cols = state.col_actions.size();
+    //         // assumes double expand is ok (it is?)
+    //         // matrix_node->expand(rows, cols);
+    //         matrix_node->chance_data_matrix.fill(rows, cols);
+
+    //         std::vector<int> &I = matrix_node->I;
+    //         std::vector<int> &J = matrix_node->J;
+    //         // current best strategy. used to calculate best response values
+    //         // entries correspond to I, J entires and order. It is a permuted submatrix of the full matrix, basically.
+    //         typename Types::VectorReal &row_solution = matrix_node->row_solution;
+    //         typename Types::VectorReal &col_solution = matrix_node->col_solution;
+
+    //         // I,J are the only places we can use prior solve info
+    //         // either already there or init to 0
+    //         I.push_back(matrix_node->row_pricipal_idx);
+    //         J.push_back(matrix_node->col_pricipal_idx);
+
+    //         bool smaller_bounds = false;
+    //         bool new_action = true;
+    //         int latest_row_idx = matrix_node->row_pricipal_idx;
+    //         int latest_col_idx = matrix_node->col_pricipal_idx;
+    //         bool solved_exactly = true;
+
+    //         while (!fuzzy_equals(alpha, beta) && (smaller_bounds || new_action))
+    //         {
+
+    //             // get entry values/bounds for newly expanded sub game, use last added actions
+
+    //             for (const int row_idx : I)
+    //             {
+    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx, latest_col_idx);
+    //                 solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, row_idx, latest_col_idx);
+    //             }
+
+    //             for (const int col_idx : J)
+    //             {
+    //                 Data &data = matrix_node->chance_data_matrix.get(latest_row_idx, col_idx);
+    //                 solved_exactly &= try_solve_chance_branches(max_depth, device, state, model, matrix_node, latest_row_idx, col_idx);
+    //             }
+
+    //             // solve newly expanded and explored game
+
+    //             int entry_idx = 0;
+    //             if (solved_exactly)
+    //             {
+    //                 typename Types::MatrixValue matrix{I.size(), J.size()};
+    //                 for (auto row_idx : I)
+    //                 {
+    //                     for (auto col_idx : J)
+    //                     {
+    //                         const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+    //                         matrix[entry_idx] = data.alpha_explored;
+    //                         ++entry_idx;
+    //                     }
+    //                 }
+    //                 LRSNash::solve(matrix, row_solution, col_solution);
+    //             }
+    //             else
+    //             {
+    //                 typename Types::MatrixValue alpha_matrix{I.size(), J.size()}, beta_matrix{I.size(), J.size()};
+    //                 for (auto row_idx : I)
+    //                 {
+    //                     for (auto col_idx : J)
+    //                     {
+    //                         const Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+    //                         alpha_matrix[entry_idx] = static_cast<Real>(data.alpha_explored + data.unexplored * min_val);
+    //                         beta_matrix[entry_idx] = static_cast<Real>(data.beta_explored + data.unexplored * max_val);
+    //                         ++entry_idx;
+    //                     }
+    //                 }
+    //                 typename Types::VectorReal temp;
+    //                 LRSNash::solve(alpha_matrix, row_solution, temp);
+    //                 temp.clear();
+    //                 LRSNash::solve(beta_matrix, temp, col_solution);
+    //             }
+
+    //             std::pair<int, Real>
+    //                 iv = best_response_row(
+    //                     max_depth,
+    //                     device,
+    //                     state,
+    //                     model,
+    //                     matrix_node,
+    //                     alpha, max_val,
+    //                     col_solution);
+
+    //             std::pair<int, Real>
+    //                 jv = best_response_col(
+    //                     max_depth,
+    //                     device,
+    //                     state,
+    //                     model,
+    //                     matrix_node,
+    //                     min_val, beta,
+    //                     row_solution);
+
+    //             // prune this node if no best response is as good as alpha/beta
+    //             if (iv.first == -1)
+    //             {
+    //                 return {min_val, min_val};
+    //             }
+    //             if (jv.first == -1)
+    //             {
+    //                 return {max_val, max_val};
+    //             }
+
+    //             smaller_bounds = false;
+    //             new_action = false;
+    //             latest_row_idx = iv.first;
+    //             latest_col_idx = jv.first;
+
+    //             if (std::find(I.begin(), I.end(), latest_row_idx) == I.end())
+    //             {
+    //                 I.push_back(latest_row_idx);
+    //                 new_action = true;
+    //             }
+    //             if (std::find(J.begin(), J.end(), latest_col_idx) == J.end())
+    //             {
+    //                 J.push_back(latest_col_idx);
+    //                 new_action = true;
+    //             }
+    //             if (jv.second > alpha)
+    //             {
+    //                 alpha = jv.second;
+    //                 smaller_bounds = true;
+    //             }
+    //             if (iv.second < beta)
+    //             {
+    //                 beta = iv.second;
+    //                 smaller_bounds = true;
+    //             }
+    //         }
+
+    //         matrix_node->row_pricipal_idx = I[std::distance(row_solution.begin(), std::max_element(row_solution.begin(), row_solution.end()))];
+    //         matrix_node->col_pricipal_idx = J[std::distance(col_solution.begin(), std::max_element(col_solution.begin(), col_solution.end()))];
+
+    //         return {alpha, beta};
+    //     }
+
+    //     std::pair<int, Real>
+    //     best_response_row(
+    //         const size_t max_depth,
+    //         Types::PRNG &device,
+    //         const Types::State &state,
+    //         Types::Model &model,
+    //         MatrixNode *matrix_node,
+    //         Real alpha, Real beta,
+    //         Types::VectorReal &col_strategy) const
+    //     {
+    //         std::vector<int> &I = matrix_node->I;
+    //         std::vector<int> &J = matrix_node->J;
+    //         int best_row_idx = -1;
+
+    //         for (int row_idx = 0; row_idx < state.row_actions.size(); ++row_idx)
+    //         {
+    //             const auto row_action = state.row_actions[row_idx];
+
+    //             const bool skip_exploration = (std::find(I.begin(), I.end(), row_idx) != I.end());
+
+    //             // 'priority' is the product of the opposing and 'chance' players probability
+    //             // its clearly what we want to minimize rather than just the chance component
+    //             Real max_priority{0}, expected_value{0}, total_unexplored{0};
+    //             std::vector<Real> exploration_priorities{};
+    //             int col_idx, next_j;
+    //             for (int j = 0; j < J.size(); ++j)
+    //             {
+    //                 const int col_idx_temp = J[j];
+    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx_temp);
+    //                 // we still have to calculate expected score to return -1 if pruning is called for
+    //                 expected_value += col_strategy[j] * data.beta_explored;
+
+    //                 const Real priority =
+    //                     (skip_exploration || (data.tries >= max_tries))
+    //                         ? Real{0}
+    //                         : Real{col_strategy[j] * data.unexplored};
+    //                 total_unexplored += priority;
+    //                 exploration_priorities.push_back(priority);
+    //                 if (priority > max_priority)
+    //                 {
+    //                     col_idx = col_idx_temp;
+    //                     max_priority = priority;
+    //                     next_j = j;
+    //                 }
+    //             }
+
+    //             while (
+    //                 (max_priority > Real{0}) &&
+    //                 (Real{expected_value + beta * total_unexplored} >= alpha))
+    //             {
+    //                 const auto col_action = state.col_actions[col_idx];
+
+    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+
+    //                 bool produced_new_branch = false;
+    //                 for (; data.tries < max_tries; ++data.tries)
+    //                 {
+    //                     typename Types::State state_copy{state};
+    //                     const typename Types::Seed seed{device.uniform_64()};
+    //                     state_copy.randomize_transition(seed);
+    //                     state_copy.apply_actions(row_action, col_action);
+    //                     const size_t obs_hash = hasher(state_copy.get_obs());
+
+    //                     if (data.branches.find(obs_hash) == data.branches.end())
+    //                     {
+    //                         produced_new_branch = true;
+    //                         // data.branches.emplace(obs_hash, state_copy, seed);
+
+    //                         Branch new_branch{state_copy, seed};
+
+    //                         new_branch.matrix_node->depth = matrix_node->depth + 1;
+    //                         const auto prob = new_branch.prob;
+
+    //                         auto alpha_beta_pair = double_oracle(
+    //                             max_depth,
+    //                             device,
+    //                             state_copy,
+    //                             model,
+    //                             new_branch.matrix_node.get(),
+    //                             min_val, max_val);
+
+    //                         data.alpha_explored += alpha_beta_pair.first * prob;
+    //                         data.beta_explored += alpha_beta_pair.second * prob;
+    //                         expected_value += alpha_beta_pair.second * prob * col_strategy[next_j];
+
+    //                         data.unexplored -= prob;
+    //                         total_unexplored -= prob * col_strategy[next_j];
+    //                         exploration_priorities[next_j] -= prob * col_strategy[next_j];
+
+    //                         break;
+    //                     }
+    //                 }
+
+    //                 if (!produced_new_branch)
+    //                 {
+    //                     exploration_priorities[next_j] = typename Types::Q{0};
+    //                 }
+
+    //                 max_priority = typename Types::Q{0};
+    //                 for (int j = 0; j < J.size(); ++j)
+    //                 {
+    //                     const Real priority = exploration_priorities[j];
+    //                     if (priority > max_priority)
+    //                     {
+    //                         col_idx = J[j];
+    //                         max_priority = priority;
+    //                         next_j = j;
+    //                     }
+    //                 }
+    //             }
+
+    //             if (expected_value >= alpha || (best_row_idx == -1 && fuzzy_equals(expected_value, alpha)))
+    //             {
+    //                 best_row_idx = row_idx;
+    //                 alpha = expected_value;
+    //             }
+    //         }
+    //         return {best_row_idx, alpha};
+    //     }
+
+    //     std::pair<int, Real>
+    //     best_response_col(
+    //         const size_t max_depth,
+    //         Types::PRNG &device,
+    //         const Types::State &state,
+    //         Types::Model &model,
+    //         MatrixNode *matrix_node,
+    //         Real alpha, Real beta,
+    //         Types::VectorReal &row_strategy) const
+    //     {
+    //         std::vector<int> &I = matrix_node->I;
+    //         std::vector<int> &J = matrix_node->J;
+    //         int best_col_idx = -1;
+
+    //         for (int col_idx = 0; col_idx < state.col_actions.size(); ++col_idx)
+    //         {
+    //             const auto col_action = state.col_actions[col_idx];
+
+    //             const bool skip_exploration = (std::find(J.begin(), J.end(), col_idx) != J.end());
+
+    //             // 'priority' is the product of the opposing and 'chance' players probability
+    //             // its clearly what we want to minimize rather than just the chance component
+    //             Real max_priority{0}, expected_value{0}, total_unexplored{0};
+    //             std::vector<Real> exploration_priorities{};
+    //             int row_idx, next_i;
+    //             for (int i = 0; i < I.size(); ++i)
+    //             {
+    //                 const int row_idx_temp = I[i];
+    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx_temp, col_idx);
+    //                 // we still have to calculate expected score to return -1 if pruning is called for
+    //                 expected_value += row_strategy[i] * data.alpha_explored;
+
+    //                 const Real priority =
+    //                     (skip_exploration || (data.tries >= max_tries))
+    //                         ? Real{0}
+    //                         : Real{row_strategy[i] * data.unexplored};
+
+    //                 total_unexplored += priority;
+    //                 exploration_priorities.push_back(priority);
+    //                 if (priority > max_priority)
+    //                 {
+    //                     row_idx = row_idx_temp;
+    //                     max_priority = priority;
+    //                     next_i = i;
+    //                 }
+    //             }
+
+    //             while (
+    //                 (max_priority > Real{0}) &&
+    //                 (Real{expected_value + alpha * total_unexplored} <= beta))
+    //             {
+    //                 const auto row_action = state.row_actions[row_idx];
+
+    //                 Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+
+    //                 bool produced_new_branch = false;
+    //                 for (; data.tries < max_tries; ++data.tries)
+    //                 {
+    //                     typename Types::State state_copy{state};
+    //                     const typename Types::Seed seed{device.uniform_64()};
+    //                     state_copy.randomize_transition(seed);
+    //                     state_copy.apply_actions(row_action, col_action);
+    //                     const size_t obs_hash = hasher(state_copy.get_obs());
+
+    //                     if (data.branches.find(obs_hash) == data.branches.end())
+    //                     {
+    //                         produced_new_branch = true;
+    //                         // Branch &new_branch = (*(data.branches.emplace(obs_hash, state_copy, seed).first)).second;
+    //                         Branch new_branch{state_copy, seed};
+
+    //                         new_branch.matrix_node->depth = matrix_node->depth + 1;
+    //                         const auto prob = new_branch.prob;
+
+    //                         auto alpha_beta_pair = double_oracle(
+    //                             max_depth,
+    //                             device,
+    //                             state_copy,
+    //                             model,
+    //                             new_branch.matrix_node.get(),
+    //                             min_val, max_val); // TODO alpha/beta
+
+    //                         data.alpha_explored += alpha_beta_pair.first * prob;
+    //                         data.beta_explored += alpha_beta_pair.second * prob;
+    //                         expected_value += alpha_beta_pair.first * prob * row_strategy[next_i];
+
+    //                         data.unexplored -= prob;
+    //                         total_unexplored -= prob * row_strategy[next_i];
+    //                         exploration_priorities[next_i] -= prob * row_strategy[next_i];
+
+    //                         break;
+    //                     }
+    //                 }
+
+    //                 if (!produced_new_branch)
+    //                 {
+    //                     exploration_priorities[next_i] = typename Types::Q{0};
+    //                 }
+
+    //                 max_priority = typename Types::Q{0};
+    //                 for (int i = 0; i < I.size(); ++i)
+    //                 {
+    //                     const Real priority = exploration_priorities[i];
+    //                     if (priority > max_priority)
+    //                     {
+    //                         row_idx = I[i];
+    //                         max_priority = priority;
+    //                         next_i = i;
+    //                     }
+    //                 }
+    //             }
+
+    //             if (expected_value <= beta || (best_col_idx == -1 && fuzzy_equals(expected_value, beta)))
+    //             {
+    //                 best_col_idx = col_idx;
+    //                 beta = expected_value;
+    //             }
+    //         }
+    //         return {best_col_idx, beta};
+    //     }
+
+    // private:
+    //     template <template <typename> typename Wrapper, typename T>
+    //     inline bool fuzzy_equals(Wrapper<T> x, Wrapper<T> y) const
+    //     {
+    //         if constexpr (std::is_same_v<T, mpq_class>)
+    //         {
+    //             mpq_ptr a = x.value.get_mpq_t();
+    //             mpq_ptr b = y.value.get_mpq_t();
+    //             mpq_canonicalize(a);
+    //             mpq_canonicalize(b);
+    //             bool answer = mpq_equal(a, b);
+    //             return answer;
+    //         }
+    //         else
+    //         {
+    //             static const Real epsilon{Rational{1, 1 << 24}};
+    //             static const Real neg_epsilon{Rational{-1, 1 << 24}};
+    //             Wrapper<T> z{x - y};
+    //             return neg_epsilon < z && z < epsilon;
+    //         }
+    //     }
+
+    //     template <template <typename> typename Wrapper, typename T>
+    //     inline bool fuzzy_greater(Wrapper<T> x, Wrapper<T> y) const
+    //     {
+    //         if constexpr (std::is_same_v<T, mpq_class>)
+    //         {
+    //             return x > y;
+    //         }
+    //         else
+    //         {
+    //             static const Real epsilon{Rational{1, 1 << 24}};
+    //             bool a = x > y + epsilon;
+    //             return a;
+    //         }
+    //     }
+
+    //     inline bool try_solve_chance_branches(
+    //         const size_t max_depth,
+    //         Types::PRNG &device,
+    //         const Types::State &state,
+    //         Types::Model &model,
+    //         MatrixNode *matrix_node,
+    //         int row_idx, int col_idx) const
+    //     {
+    //         Data &data = matrix_node->chance_data_matrix.get(row_idx, col_idx);
+
+    //         const auto row_action = state.row_actions[row_idx];
+    //         const auto col_action = state.col_actions[col_idx];
+
+    //         for (; data.tries < max_tries && data.unexplored > typename Types::Prob{0}; ++data.tries)
+    //         {
+    //             typename Types::State state_copy{state};
+    //             const typename Types::Seed seed{device.uniform_64()};
+    //             state_copy.randomize_transition(seed);
+    //             state_copy.apply_actions(row_action, col_action);
+    //             const size_t obs_hash = hasher(state_copy.get_obs());
+
+    //             if (data.branches.find(obs_hash) == data.branches.end())
+    //             {
+    //                 // Branch &new_branch = (*(data.branches.emplace(obs_hash, state_copy, seed).first)).second;
+    //                 Branch new_branch{state_copy, seed};
+
+    //                 new_branch.matrix_node->depth = matrix_node->depth + 1;
+
+    //                 const auto alpha_beta =
+    //                     double_oracle(
+    //                         max_depth,
+    //                         device,
+    //                         state_copy,
+    //                         model,
+    //                         new_branch.matrix_node.get(),
+    //                         min_val, max_val);
+
+    //                 data.alpha_explored += alpha_beta.first * new_branch.prob;
+    //                 data.beta_explored += alpha_beta.second * new_branch.prob;
+    //                 data.unexplored -= new_branch.prob;
+    //             }
+    //         }
+
+    //         const bool solved_exactly = (data.alpha_explored == data.beta_explored) && (data.unexplored == Real{Rational<>{0}});
+    //         return solved_exactly;
+    //     };
+
+    //     Real row_alpha_beta(
+    //         Types::State &state,
+    //         Types::Model &model,
+    //         MatrixNode *matrix_node,
+    //         Real alpha,
+    //         Real beta)
+    //     {
+    //         return max_val;
+    //     }
+
+    //     Real col_alpha_beta(
+    //         Types::State &state,
+    //         Types::Model &model,
+    //         MatrixNode *matrix_node,
+    //         Real alpha,
+    //         Real beta)
+    //     {
+    //         return min_val;
+    //     }
+    //     // Serialized AlphaBeta, TODO
+
+    //     static bool dont_terminate(
+    //         Types::PRNG &,
+    //         const Data &)
+    //     {
+    //         return false;
+    //     };
+
+    //     static bool after_some_time(
+    //         Types::PRNG &device,
+    //         const Data &data)
+    //     {
+    //         const typename Types::Prob x{Rational<>{1, 4}};
+    //         return (data.next_chance_idx > 1 &&
+    //                 data.unexplored < x);
+    //     }
+
+    //     static bool thing(
+    //         Types::PRNG &device,
+    //         const Data &data)
+    //     {
+    //         // return (data.unexplored + (1 / 2) > )
+    //         return false;
+    //     }
     };
 };

--- a/src/algorithm/solver/alpha-beta.hh
+++ b/src/algorithm/solver/alpha-beta.hh
@@ -240,10 +240,10 @@ struct AlphaBeta : Types
                 stats.row_pricipal_idx = I[std::distance(row_strategy.begin(), std::max_element(row_strategy.begin(), row_strategy.end()))];
                 stats.col_pricipal_idx = J[std::distance(col_strategy.begin(), std::max_element(col_strategy.begin(), col_strategy.end()))];
             }
-            I.clear();
-            J.clear();
-            row_strategy.clear();
-            col_strategy.clear();
+            // I.clear();
+            // J.clear();
+            // row_strategy.clear();
+            // col_strategy.clear();
             // stats.data_matrix.clear();
 
             // I.resize(0);

--- a/src/algorithm/solver/alpha-beta.hh
+++ b/src/algorithm/solver/alpha-beta.hh
@@ -96,7 +96,8 @@ struct AlphaBeta : Types
             if (state.is_terminal())
             {
                 matrix_node->set_terminal();
-                return {state.payoff.get_row_value(), state.payoff.get_row_value()};
+                const typename Types::Value payoff = state.get_payoff();
+                return {payoff.get_row_value(), payoff.get_row_value()};
             }
             if (max_depth > 0 && stats.depth >= max_depth)
             {

--- a/src/algorithm/solver/alpha-beta.hh
+++ b/src/algorithm/solver/alpha-beta.hh
@@ -33,6 +33,8 @@ struct AlphaBeta : Types
 
         int row_pricipal_idx = 0, col_pricipal_idx = 0;
         std::vector<int> I{}, J{};
+
+        typename Types::Value solved_value;
     };
     struct ChanceStats
     {
@@ -97,6 +99,7 @@ struct AlphaBeta : Types
             {
                 matrix_node->set_terminal();
                 const typename Types::Value payoff = state.get_payoff();
+                matrix_node->stats.solved_value = payoff;
                 return {payoff.get_row_value(), payoff.get_row_value()};
             }
             if (max_depth > 0 && stats.depth >= max_depth)

--- a/src/algorithm/solver/full-traversal.hh
+++ b/src/algorithm/solver/full-traversal.hh
@@ -41,6 +41,7 @@ struct FullTraversal : Types
         std::vector<typename Types::Obs> chance_actions;
         std::vector<typename Types::Prob> chance_strategy;
         typename Types::Mutex mutex{};
+        bool is_solved = false;
     };
     using MatrixNode = typename NodePair<Types, MatrixStats, ChanceStats>::MatrixNode;
     using ChanceNode = typename NodePair<Types, MatrixStats, ChanceStats>::ChanceNode;
@@ -141,6 +142,11 @@ struct FullTraversal : Types
                         continue;
                     }
 
+                    if (chance_node->stats.is_solved)
+                    {
+                        continue;
+                    }
+
                     std::cout << "FULL TRAVERSAL: " << row_idx << ' ' << col_idx << std::endl;
 
                     auto &chance_actions = chance_node->stats.chance_actions;
@@ -164,6 +170,7 @@ struct FullTraversal : Types
                         stats.matrix_node_count += matrix_node_next->stats.matrix_node_count;
                     }
 
+                    chance_node->stats.is_solved = true;
                     chance_node->stats.mutex.unlock();
                 }
             }

--- a/src/algorithm/solver/full-traversal.hh
+++ b/src/algorithm/solver/full-traversal.hh
@@ -94,7 +94,6 @@ struct FullTraversal : Types
             {
                 stats.payoff = state.get_payoff();
                 matrix_node->set_terminal();
-                // return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};            *output_real = stats.payoff.get_row_value();
                 return;
             }
             if (stats.depth >= max_depth)
@@ -103,7 +102,6 @@ struct FullTraversal : Types
                 model.inference(std::move(state), output);
                 stats.payoff = output.value;
                 matrix_node->set_terminal();
-                // return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};
                 return;
             }
 
@@ -147,8 +145,6 @@ struct FullTraversal : Types
                         continue;
                     }
 
-                    // std::cout << "FULL TRAVERSAL: " << row_idx << ' ' << col_idx << std::endl;
-
                     auto &chance_actions = chance_node->stats.chance_actions;
                     state.get_chance_actions(row_action, col_action, chance_actions);
 
@@ -176,8 +172,6 @@ struct FullTraversal : Types
             }
 
             stats.payoff = LRSNash::solve(stats.nash_payoff_matrix, stats.row_solution, stats.col_solution);
-            // return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};
-            return;
         }
     };
 };

--- a/src/algorithm/solver/full-traversal.hh
+++ b/src/algorithm/solver/full-traversal.hh
@@ -43,34 +43,25 @@ struct FullTraversal : Types
     class Search
     {
     public:
-        const int max_depth = -1;
 
         Search() {}
-        Search(const int max_depth) : max_depth{max_depth} {}
 
         std::pair<typename Types::Real, typename Types::Real>
         run(
+            const size_t max_depth,
             Types::PRNG &,
             const Types::State &state,
             Types::Model &model,
             MatrixNode &matrix_node) const
         {
             auto state_ = state;
-            auto pair = run_(state_, model, &matrix_node);
+            auto pair = run_(max_depth, state_, model, &matrix_node);
             return pair;
-        }
-
-        void run(
-            const Types::State &state,
-            Types::Model &model,
-            MatrixNode &matrix_node) const
-        {
-            auto state_ = state;
-            run_(state_, model, &matrix_node);
         }
 
         std::pair<typename Types::Real, typename Types::Real>
         run_(
+            const size_t max_depth,
             Types::State &state,
             Types::Model &model,
             MatrixNode *matrix_node) const
@@ -89,7 +80,7 @@ struct FullTraversal : Types
                 matrix_node->set_terminal();
                 return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};
             }
-            if (max_depth > 0 && stats.depth >= max_depth)
+            if (stats.depth >= max_depth)
             {
                 typename Types::ModelOutput output;
                 model.inference(std::move(state), output);
@@ -124,7 +115,7 @@ struct FullTraversal : Types
                         matrix_node_next->stats.prob = state_copy.prob;
                         chance_node->stats.chance_strategy.push_back(state_copy.prob);
 
-                        auto value_ = run_(state_copy, model, matrix_node_next);
+                        auto value_ = run_(max_depth, state_copy, model, matrix_node_next);
 
                         stats.nash_payoff_matrix.get(row_idx, col_idx) += 
                             matrix_node_next->stats.payoff * 

--- a/src/algorithm/solver/full-traversal.hh
+++ b/src/algorithm/solver/full-traversal.hh
@@ -76,7 +76,7 @@ struct FullTraversal : Types
 
             if (state.is_terminal())
             {
-                stats.payoff = state.payoff;
+                stats.payoff = state.get_payoff();
                 matrix_node->set_terminal();
                 return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};
             }
@@ -98,6 +98,9 @@ struct FullTraversal : Types
             {
                 for (int col_idx = 0; col_idx < cols; ++col_idx)
                 {
+
+                    std::cout << "FULL TRAVERSAL: " << row_idx << ' ' << col_idx << std::endl;
+
                     const typename Types::Action &row_action{state.row_actions[row_idx]};
                     const typename Types::Action &col_action{state.col_actions[col_idx]};
                     

--- a/src/algorithm/solver/full-traversal.hh
+++ b/src/algorithm/solver/full-traversal.hh
@@ -147,7 +147,7 @@ struct FullTraversal : Types
                         continue;
                     }
 
-                    std::cout << "FULL TRAVERSAL: " << row_idx << ' ' << col_idx << std::endl;
+                    // std::cout << "FULL TRAVERSAL: " << row_idx << ' ' << col_idx << std::endl;
 
                     auto &chance_actions = chance_node->stats.chance_actions;
                     state.get_chance_actions(row_action, col_action, chance_actions);

--- a/src/algorithm/solver/full-traversal.hh
+++ b/src/algorithm/solver/full-traversal.hh
@@ -7,6 +7,7 @@
 #include <model/model.hh>
 #include <tree/tree.hh>
 #include <algorithm/algorithm.hh>
+#include <thread>
 
 /*
     This algorithm expands a node into a tree that is one-to-one with the abstract game tree
@@ -19,7 +20,7 @@
 template <
     CONCEPT(IsSingleModelTypes, Types),
     template <typename...> typename NodePair = DefaultNodes>
-requires IsChanceStateTypes<Types> 
+    requires IsChanceStateTypes<Types>
 struct FullTraversal : Types
 {
     struct MatrixStats
@@ -31,11 +32,15 @@ struct FullTraversal : Types
         size_t matrix_node_count = 1;
         unsigned int depth = 0;
         typename Types::Prob prob;
+
+        typename Types::Mutex mutex{};
+        bool is_expanded = false;
     };
     struct ChanceStats
     {
         std::vector<typename Types::Obs> chance_actions;
         std::vector<typename Types::Prob> chance_strategy;
+        typename Types::Mutex mutex{};
     };
     using MatrixNode = typename NodePair<Types, MatrixStats, ChanceStats>::MatrixNode;
     using ChanceNode = typename NodePair<Types, MatrixStats, ChanceStats>::ChanceNode;
@@ -43,7 +48,6 @@ struct FullTraversal : Types
     class Search
     {
     public:
-
         Search() {}
 
         std::pair<typename Types::Real, typename Types::Real>
@@ -52,20 +56,31 @@ struct FullTraversal : Types
             Types::PRNG &,
             const Types::State &state,
             Types::Model &model,
-            MatrixNode &matrix_node) const
+            MatrixNode &matrix_node,
+            const size_t threads = 1) const
         {
             auto state_ = state;
-            auto pair = run_(max_depth, state_, model, &matrix_node);
-            return pair;
+            std::thread thread_pool[threads];
+            for (int i = 0; i < threads; ++i)
+            {
+                thread_pool[i] = std::thread(
+                    &Search::run_, this, max_depth, &state_, &model, &matrix_node);
+            }
+            for (int i = 0; i < threads; ++i)
+            {
+                thread_pool[i].join();
+            }
+            return {matrix_node.stats.payoff.get_row_value(), matrix_node.stats.payoff.get_row_value()};
         }
 
-        std::pair<typename Types::Real, typename Types::Real>
-        run_(
+        void run_(
             const size_t max_depth,
-            Types::State &state,
-            Types::Model &model,
+            Types::State *state_ptr,
+            Types::Model *model_ptr,
             MatrixNode *matrix_node) const
         {
+            typename Types::State &state = *state_ptr;
+            typename Types::Model &model = *model_ptr;
             // expand node
             state.get_actions();
             const size_t rows = state.row_actions.size();
@@ -78,7 +93,8 @@ struct FullTraversal : Types
             {
                 stats.payoff = state.get_payoff();
                 matrix_node->set_terminal();
-                return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};
+                // return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};            *output_real = stats.payoff.get_row_value();
+                return;
             }
             if (stats.depth >= max_depth)
             {
@@ -86,25 +102,47 @@ struct FullTraversal : Types
                 model.inference(std::move(state), output);
                 stats.payoff = output.value;
                 matrix_node->set_terminal();
-                return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};
+                // return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};
+                return;
             }
-            
-            stats.nash_payoff_matrix.fill(rows, cols);
-            stats.row_solution.resize(rows);
-            stats.col_solution.resize(cols);
+
+            stats.mutex.lock();
+            if (!stats.is_expanded)
+            {
+                stats.nash_payoff_matrix.fill(rows, cols);
+                stats.row_solution.resize(rows);
+                stats.col_solution.resize(cols);
+                for (int row_idx = 0; row_idx < rows; ++row_idx)
+                {
+                    for (int col_idx = 0; col_idx < cols; ++col_idx)
+                    {
+                        const typename Types::Action &row_action{state.row_actions[row_idx]};
+                        const typename Types::Action &col_action{state.col_actions[col_idx]};
+
+                        ChanceNode *chance_node = matrix_node->access(row_idx, col_idx);
+                    }
+                }
+            }
+            stats.is_expanded = true;
+            stats.mutex.unlock();
 
             // recurse
             for (int row_idx = 0; row_idx < rows; ++row_idx)
             {
                 for (int col_idx = 0; col_idx < cols; ++col_idx)
                 {
+                    const typename Types::Action &row_action{state.row_actions[row_idx]};
+                    const typename Types::Action &col_action{state.col_actions[col_idx]};
+
+                    ChanceNode *chance_node = matrix_node->access(row_idx, col_idx);
+
+                    if (!chance_node->stats.mutex.try_lock())
+                    {
+                        continue;
+                    }
 
                     std::cout << "FULL TRAVERSAL: " << row_idx << ' ' << col_idx << std::endl;
 
-                    const typename Types::Action &row_action{state.row_actions[row_idx]};
-                    const typename Types::Action &col_action{state.col_actions[col_idx]};
-                    
-                    ChanceNode *chance_node = matrix_node->access(row_idx, col_idx);
                     auto &chance_actions = chance_node->stats.chance_actions;
                     state.get_chance_actions(row_action, col_action, chance_actions);
 
@@ -118,18 +156,21 @@ struct FullTraversal : Types
                         matrix_node_next->stats.prob = state_copy.prob;
                         chance_node->stats.chance_strategy.push_back(state_copy.prob);
 
-                        auto value_ = run_(max_depth, state_copy, model, matrix_node_next);
+                        run_(max_depth, &state_copy, model_ptr, matrix_node_next);
 
-                        stats.nash_payoff_matrix.get(row_idx, col_idx) += 
-                            matrix_node_next->stats.payoff * 
+                        stats.nash_payoff_matrix.get(row_idx, col_idx) +=
+                            matrix_node_next->stats.payoff *
                             typename Types::Real{matrix_node_next->stats.prob};
                         stats.matrix_node_count += matrix_node_next->stats.matrix_node_count;
                     }
+
+                    chance_node->stats.mutex.unlock();
                 }
             }
 
             stats.payoff = LRSNash::solve(stats.nash_payoff_matrix, stats.row_solution, stats.col_solution);
-            return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};
+            // return {stats.payoff.get_row_value(), stats.payoff.get_row_value()};
+            return;
         }
     };
 };

--- a/src/algorithm/tree-bandit/tree/tree-bandit.hh
+++ b/src/algorithm/tree-bandit/tree/tree-bandit.hh
@@ -67,7 +67,12 @@ struct TreeBandit : Types
             for (size_t iteration = 0; iteration < iterations; ++iteration)
             {
                 typename Types::State state_copy = state;
+                if (iteration == 5061)
+                {
+                    state_copy.print_log = true;
+                }
                 state_copy.randomize_transition(device);
+                std::cout << iteration << std::endl;
                 this->run_iteration(device, state_copy, model, &matrix_node, model_output);
             }
             const auto end = std::chrono::high_resolution_clock::now();

--- a/src/algorithm/tree-bandit/tree/tree-bandit.hh
+++ b/src/algorithm/tree-bandit/tree/tree-bandit.hh
@@ -67,12 +67,13 @@ struct TreeBandit : Types
             for (size_t iteration = 0; iteration < iterations; ++iteration)
             {
                 typename Types::State state_copy = state;
-                if (iteration == 5061)
-                {
-                    state_copy.print_log = true;
-                }
+                // if (iteration == 5061)
+                // {
+                //     state_copy.print_log = true;
+                // }
                 state_copy.randomize_transition(device);
-                std::cout << iteration << std::endl;
+                // std::cout << state.row_actions.size() << std::endl;
+                // std::cout << state_copy.row_actions.size() << std::endl;
                 this->run_iteration(device, state_copy, model, &matrix_node, model_output);
             }
             const auto end = std::chrono::high_resolution_clock::now();
@@ -96,6 +97,7 @@ struct TreeBandit : Types
             }
             else
             {
+                // std::cout << '!' << state.row_actions.size() << std::endl;
                 if (!matrix_node->is_expanded())
                 {
                     if constexpr (!std::is_same_v<typename Options::NodeActions, void>)

--- a/src/libpinyon/generator.hh
+++ b/src/libpinyon/generator.hh
@@ -1,92 +1,92 @@
-#pragma once
+// #pragma once
 
-#include <tuple>
-#include <type_traits>
-#include <ranges>
-#include <functional>
+// #include <tuple>
+// #include <type_traits>
+// #include <ranges>
+// #include <functional>
 
-/*
+// /*
 
-Provides an object with a range interface. There are 3 main parameters
+// Provides an object with a range interface. There are 3 main parameters
 
-1. A Collection of containers
-2. A type Output that is the return type of the iterator
-3. A function from the cartesian product of the containers that returns type Output
+// 1. A Collection of containers
+// 2. A type Output that is the return type of the iterator
+// 3. A function from the cartesian product of the containers that returns type Output
 
-Example 
+// Example 
 
-int function (int a, int b) {
-    return 10 * a + b;
-}
-auto generator<Output>({1, 2}, {3, 4});
-auto results_vec = std::vector<int>{};
+// int function (int a, int b) {
+//     return 10 * a + b;
+// }
+// auto generator<Output>({1, 2}, {3, 4});
+// auto results_vec = std::vector<int>{};
 
-for (auto x : generator) {
-    results_vec.push_back(x);
-}
+// for (auto x : generator) {
+//     results_vec.push_back(x);
+// }
 
-// results_vec = {13, 14, 23, 24}
+// // results_vec = {13, 14, 23, 24}
 
-*/
+// */
 
-template <typename Output, typename... Containers>
-struct CartesianProductGenerator
-{
-    std::tuple<Containers...> containers;
-    using Tuple = std::tuple<typename Containers::value_type...>;
-    using Product = decltype(std::apply([](auto &...containers)
-                                        { return std::views::cartesian_product(containers...); },
-                                        containers));
-    using It = std::ranges::iterator_t<Product>;
+// template <typename Output, typename... Containers>
+// struct CartesianProductGenerator
+// {
+//     std::tuple<Containers...> containers;
+//     using Tuple = std::tuple<typename Containers::value_type...>;
+//     using Product = decltype(std::apply([](auto &...containers)
+//                                         { return std::views::cartesian_product(containers...); },
+//                                         containers));
+//     using It = std::ranges::iterator_t<Product>;
 
-    Product cart_prod_view = std::apply([](auto &...containers)
-                                        { return std::views::cartesian_product(containers...); },
-                                        containers);
+//     Product cart_prod_view = std::apply([](auto &...containers)
+//                                         { return std::views::cartesian_product(containers...); },
+//                                         containers);
 
-    using Function = std::function<Output(Tuple)>;
-    Function function;
+//     using Function = std::function<Output(Tuple)>;
+//     Function function;
 
-    CartesianProductGenerator(Function function, Containers ...args)
-        : function{function}, containers(std::forward<Containers>(args)...)
-    {
-    }
+//     CartesianProductGenerator(Function function, Containers ...args)
+//         : function{function}, containers(std::forward<Containers>(args)...)
+//     {
+//     }
 
-    class Iterator;
+//     class Iterator;
 
-    Iterator begin()
-    {
-        return Iterator(cart_prod_view.begin(), this);
-    }
+//     Iterator begin()
+//     {
+//         return Iterator(cart_prod_view.begin(), this);
+//     }
 
-    Iterator end()
-    {
-        return Iterator(cart_prod_view.end(), this);
-    }
+//     Iterator end()
+//     {
+//         return Iterator(cart_prod_view.end(), this);
+//     }
 
-    class Iterator : public It
-    {
-    public:
-        CartesianProductGenerator *ptr;
+//     class Iterator : public It
+//     {
+//     public:
+//         CartesianProductGenerator *ptr;
 
-        Iterator(const It &it, CartesianProductGenerator *ptr) : It{it}, ptr{ptr}
-        {
-        }
+//         Iterator(const It &it, CartesianProductGenerator *ptr) : It{it}, ptr{ptr}
+//         {
+//         }
 
-        Iterator &operator++()
-        {
-            It::operator++();
-            return (*this);
-        }
+//         Iterator &operator++()
+//         {
+//             It::operator++();
+//             return (*this);
+//         }
 
-        Output operator*()
-        {
-            Tuple tuple = It::operator*();
-            return (ptr->function)(tuple);
-        }
+//         Output operator*()
+//         {
+//             Tuple tuple = It::operator*();
+//             return (ptr->function)(tuple);
+//         }
 
-        bool operator==(const Iterator &other) const
-        {
-            return static_cast<const It &>(*this) == static_cast<const It &>(other);
-        }
-    };
-};
+//         bool operator==(const Iterator &other) const
+//         {
+//             return static_cast<const It &>(*this) == static_cast<const It &>(other);
+//         }
+//     };
+// };

--- a/src/libpinyon/math.hh
+++ b/src/libpinyon/math.hh
@@ -54,9 +54,9 @@ namespace math
 
     template <typename Real, typename Value, template <typename...> typename Vector, template <typename> typename Matrix>
     Real exploitability(
-        Matrix<Value> &value_matrix,
-        Vector<Real> &row_strategy,
-        Vector<Real> &col_strategy)
+        const Matrix<Value> &value_matrix,
+        const Vector<Real> &row_strategy,
+        const Vector<Real> &col_strategy)
     {
         const size_t rows = value_matrix.rows;
         const size_t cols = value_matrix.cols;

--- a/src/model/search-model.hh
+++ b/src/model/search-model.hh
@@ -55,11 +55,11 @@ struct SearchModel : Types::TypeList
         typename Types::Search search;
 
         Model(
-            const size_t iterations,
+            const size_t count,
             const Types::PRNG &device,
             const Types::Model &model,
             const Types::Search &search)
-            : count{iterations}, device{device}, model{model}, search{search}
+            : count{count}, device{device}, model{model}, search{search}
         {
         }
 

--- a/src/pinyon.hh
+++ b/src/pinyon.hh
@@ -47,6 +47,7 @@
 #include <algorithm/solver/full-traversal.hh>
 #include <algorithm/solver/alpha-beta.hh>
 #include <algorithm/solver/alpha-beta-old.hh>
+#include <algorithm/solver/alpha-beta-force.hh>
 
 // Tree
 

--- a/src/pinyon.hh
+++ b/src/pinyon.hh
@@ -19,6 +19,7 @@
 #include <state/test-states.hh>
 #include <state/random-tree.hh>
 #include <state/traversed.hh>
+#include <state/mapped-state.hh>
 #include <state/arena.hh>
 
 // Model

--- a/src/state/mapped-state.hh
+++ b/src/state/mapped-state.hh
@@ -204,7 +204,7 @@ struct MappedState : Types::TypeList
         Types::Value get_payoff() const
         {
             if (Types::State::is_terminal()) {
-                return this->get_payoff();
+                return Types::State::get_payoff();
             }
             typename Types::State state_{*this};
             state_.get_actions();

--- a/src/state/mapped-state.hh
+++ b/src/state/mapped-state.hh
@@ -94,6 +94,10 @@ struct MappedState : Types::TypeList
 
                     if (chance_data.count == 0)
                     {
+                        // for (int i = 0; i < 16; ++i) {
+                        //     std::cout << (int)state_copy.get_obs().get()[i] << ' ';
+                        // }
+                        // std::cout << std::endl;
                         chance_data.prob = state_copy.prob;
                         total_prob += state_copy.prob;
                         chance_data.seed = seed;
@@ -120,9 +124,9 @@ struct MappedState : Types::TypeList
             *node;
         std::shared_ptr<const MatrixNode>
             explored_tree;
-        typename Types::Model
+        const typename Types::Model
             model;
-        typename Types::Search
+        const typename Types::Search
             search;
         const size_t iterations;
 
@@ -170,6 +174,7 @@ struct MappedState : Types::TypeList
             const int row_idx = std::find(node->row_actions.begin(), node->row_actions.end(), row_action) - node->row_actions.begin();
             const int col_idx = std::find(node->col_actions.begin(), node->col_actions.end(), col_action) - node->col_actions.begin();
             const ChanceNode *chance_node = node->access(row_idx, col_idx);
+            // TODO sort by prob for faster AlphaBeta
             for (auto kv : chance_node->stats.map)
             {
                 chance_actions.push_back(kv.first);

--- a/src/state/mapped-state.hh
+++ b/src/state/mapped-state.hh
@@ -203,6 +203,9 @@ struct MappedState : Types::TypeList
 
         Types::Value get_payoff() const
         {
+            if (Types::State::is_terminal()) {
+                return this->get_payoff();
+            }
             typename Types::State state_{*this};
             state_.get_actions();
             typename Types::Model model_{model};

--- a/src/state/mapped-state.hh
+++ b/src/state/mapped-state.hh
@@ -204,6 +204,7 @@ struct MappedState : Types::TypeList
         Types::Value get_payoff() const
         {
             typename Types::State state_{*this};
+            state_.get_actions();
             typename Types::Model model_{model};
             typename Types::ModelOutput output;
             model_.inference(std::move(state_), output);

--- a/src/state/mapped-state.hh
+++ b/src/state/mapped-state.hh
@@ -1,0 +1,187 @@
+#include <state/state.hh>
+
+#include <tree/tree-debug.hh>
+
+#include <memory>
+#include <unordered_map>
+
+template <
+    typename Types,
+    bool renormalize = false>
+struct MappedState
+{
+
+    struct MatrixStats
+    {
+    };
+
+    struct ChanceData
+    {
+        size_t count{};
+        typename Types::Prob prob;
+        typename Types::Seed seed;
+    };
+
+    struct ChanceStats
+    {
+        std::unordered_map<
+            typename Types::Obs,
+            ChanceData,
+            typename Types::ObsHash>
+            map{};
+    };
+
+    using NodeTypes = DefaultNodes<
+        Types,
+        MatrixStats,
+        ChanceStats,
+        typename Types::VectorAction>; // actions are stored in the matrix node
+
+    using MatrixNode = NodeTypes::MatrixNode;
+    using ChanceNode = NodeTypes::ChanceNode;
+
+    static void run(
+        const size_t depth,
+        const size_t tries,
+        Types::PRNG &device,
+        NodeTypes::State &state,
+        MatrixNode *matrix_node)
+    {
+
+        if (depth <= 0 || state.is_terminal())
+        {
+            matrix_node->set_terminal();
+            return;
+        }
+
+        state.get_actions(matrix_node->row_actions, matrix_node->col_actions);
+
+        for (int row_idx = 0; row_idx < matrix_node->row_actions.size(); ++row_idx)
+        {
+            for (int col_idx = 0; col_idx < matrix_node->col_actions.size(); ++col_idx)
+            {
+
+                ChanceNode *chance_node = matrix_node->access(row_idx, col_idx);
+
+                typename Types::Prob total_prob{};
+
+                for (int t = 0; t < tries && total_prob < typename Types::Prob{1}; ++t)
+                {
+
+                    typename Types::State state_copy = state;
+                    typename Types::Seed seed{device.uniform_64()};
+                    typename Types::PRNG fixed_device{seed};
+                    state_copy.randomize_transition(fixed_device);
+                    state_copy.apply_actions(
+                        matrix_node->row_actions[row_idx],
+                        matrix_node->col_actions[col_idx]);
+
+                    MatrixNode *matrix_node_next = chance_node->access(state_copy.get_obs());
+                    auto &chance_data = chance_node->stats.map[state_copy.get_obs()];
+
+                    if (chance_data.count == 0)
+                    {
+                        chance_data.prob = state_copy.prob;
+                        total_prob += state_copy.prob;
+                        chance_data.seed = seed;
+                        run(
+                            depth - 1,
+                            tries,
+                            device,
+                            state_copy,
+                            matrix_node_next);
+                    }
+                    ++chance_data.count;
+                }
+            }
+        }
+    }
+
+    /*
+
+    Expands a shared tree around the input state by brute-forcing chance nodes.
+    This tree only stores the witnessed chance actions and their emprical probs.
+
+    Much like `FullTraversal`, this is exactly a regular Types::State but with the shared data as well.
+    When we  call `apply_actions` and transition to the of the shared tree, we mark as terminal.
+    No search is done at that moment, but calling `get_payoff` will now perform a search with a disposable root node,
+    and the model and search objects that were copied during initialization
+
+    */
+
+    class State : public Types::State
+    {
+    public:
+        const MatrixNode
+            *node;
+        std::shared_ptr<const MatrixNode>
+            explored_tree;
+        std::shared_ptr<typename Types::Model>
+            shared_model;
+        std::shared_ptr<typename Types::Search>
+            shared_search;
+        const size_t iterations;
+
+        State(
+            const size_t depth,
+            const size_t tries,
+            const size_t iterations,
+            Types::PRNG &device,
+            Types::State &state,
+            const Types::Model &model,
+            const Types::Search &search)
+            : Types::State{state},
+              iterations{iterations},
+              shared_model{std::make_shared<typename Types::Model>(model)},
+              shared_search{std::make_shared<typename Types::Search>(search)}
+        {
+            auto temp_tree = std::make_shared<MatrixNode>();
+            node = temp_tree.get();
+            run(depth, tries, device, state, temp_tree.get());
+            explored_tree = temp_tree;
+        }
+
+        void get_chance_actions(
+            Types::Action row_action,
+            Types::Action col_action,
+            std::vector<typename Types::Obs> &chance_action)
+        {
+            const int row_idx = std::find(node->row_actions.begin(), node->row_actions.end(), row_action) - node->row_actions.begin();
+            const int col_idx = std::find(node->col_actions.begin(), node->col_actions.end(), col_action) - node->col_actions.begin();
+            ChanceNode *chance_node = node->access(row_idx, col_idx);
+            chance_node->map.keys();
+            // TODO add keys to vector
+        }
+
+        void apply_actions(
+            Types::Action row_action,
+            Types::Action col_action,
+            Types::Obs chance_action)
+        {
+            const int row_idx = std::find(node->row_actions.begin(), node->row_actions.end(), row_action) - node->row_actions.begin();
+            const int col_idx = std::find(node->col_actions.begin(), node->col_actions.end(), col_action) - node->col_actions.begin();
+            ChanceNode *chance_node = node->access(row_idx, col_idx);
+            ChanceData &chance_data = chance_node->map[chance_action];
+            typename Types::PRNG device = chance_data.fixed_device;
+            Types::State::randomize_transition(device);
+            Types::State::apply_actions(row_action, col_action);
+            node = chance_node->access(Types::State::get_obs());
+            assert(chance_action == Types::State::get_obs());
+        }
+
+        bool is_terminal() const
+        {
+            return node->is_terminal();
+        }
+
+        Types::Value get_payoff()
+        {
+            typename Types::MatrixNode root{};
+            typename Types::PRNG device{};
+            shared_search->run_for_iterations(iterations, device, *this, *shared_model, root);
+            typename Types::Value value{};
+            shared_search->get_empirical_value(value);
+            return value;
+        }
+    };
+};

--- a/src/state/random-tree.hh
+++ b/src/state/random-tree.hh
@@ -82,6 +82,11 @@ struct RandomTree : Types
             transition_seed = device.uniform_64();
         }
 
+        void randomize_transition(const Types::Seed seed)
+        {
+            transition_seed = seed;
+        }
+
         void get_actions()
         {
             this->init_range_actions(rows, cols);

--- a/src/state/random-tree.hh
+++ b/src/state/random-tree.hh
@@ -228,12 +228,12 @@ struct RandomTree : Types
                         }
                         chance_strategies_[start_idx + chance_idx] = x;
                         prob_sum += x;
+                        prob_sum.canonicalize();
 
                         // decay = decay * decay;
                         // decay.canonicalize();
                     }
 
-                    prob_sum.canonicalize();
 
                     if (prob_sum == typename Types::Q{0})
                     {

--- a/src/state/random-tree.hh
+++ b/src/state/random-tree.hh
@@ -249,49 +249,49 @@ struct RandomTree : Types
     };
 };
 
-/*
+// /*
 
-Helper class to generate random tree instances for testing
+// Helper class to generate random tree instances for testing
 
-*/
+// */
 
-template <typename TypeList = RandomTreeFloatTypes>
-struct RandomTreeGenerator : CartesianProductGenerator<
-                                 W::Types::State,
-                                 std::vector<size_t>,
-                                 std::vector<size_t>,
-                                 std::vector<size_t>,
-                                 std::vector<Rational<>>,
-                                 std::vector<size_t>>
-{
-    inline static prng device{0}; // static because used in static member function, TODO
-    // This class is not used for arena, maybe remove?
+// template <typename TypeList = RandomTreeFloatTypes>
+// struct RandomTreeGenerator : CartesianProductGenerator<
+//                                  W::Types::State,
+//                                  std::vector<size_t>,
+//                                  std::vector<size_t>,
+//                                  std::vector<size_t>,
+//                                  std::vector<Rational<>>,
+//                                  std::vector<size_t>>
+// {
+//     inline static prng device{0}; // static because used in static member function, TODO
+//     // This class is not used for arena, maybe remove?
 
-    // static otherwise implcit this arg messes up signature
-    static W::Types::State constr(std::tuple<size_t, size_t, size_t, Rational<>, size_t> tuple)
-    {
-        return W::Types::State{
-            RandomTree<TypeList>{},
-            RandomTreeGenerator::device.uniform_64(),
-            std::get<0>(tuple),
-            std::get<1>(tuple),
-            std::get<1>(tuple),
-            std::get<2>(tuple),
-            std::get<3>(tuple)};
-    };
+//     // static otherwise implcit this arg messes up signature
+//     static W::Types::State constr(std::tuple<size_t, size_t, size_t, Rational<>, size_t> tuple)
+//     {
+//         return W::Types::State{
+//             RandomTree<TypeList>{},
+//             RandomTreeGenerator::device.uniform_64(),
+//             std::get<0>(tuple),
+//             std::get<1>(tuple),
+//             std::get<1>(tuple),
+//             std::get<2>(tuple),
+//             std::get<3>(tuple)};
+//     };
 
-    RandomTreeGenerator(
-        const prng &device,
-        const std::vector<size_t> &depth_bound_vec,
-        const std::vector<size_t> &actions_vec,
-        const std::vector<size_t> &chance_action_vec,
-        const std::vector<Rational<>> &chance_threshold_vec,
-        const std::vector<size_t> &trial_vec)
-        : CartesianProductGenerator<W::Types::State, std::vector<size_t>, std::vector<size_t>, std::vector<size_t>, std::vector<Rational<>>, std::vector<size_t>>
-    {
-        constr, depth_bound_vec, actions_vec, chance_action_vec, chance_threshold_vec, trial_vec
-    }
-    {
-        RandomTreeGenerator::device = prng{device};
-    }
-};
+//     RandomTreeGenerator(
+//         const prng &device,
+//         const std::vector<size_t> &depth_bound_vec,
+//         const std::vector<size_t> &actions_vec,
+//         const std::vector<size_t> &chance_action_vec,
+//         const std::vector<Rational<>> &chance_threshold_vec,
+//         const std::vector<size_t> &trial_vec)
+//         : CartesianProductGenerator<W::Types::State, std::vector<size_t>, std::vector<size_t>, std::vector<size_t>, std::vector<Rational<>>, std::vector<size_t>>
+//     {
+//         constr, depth_bound_vec, actions_vec, chance_action_vec, chance_threshold_vec, trial_vec
+//     }
+//     {
+//         RandomTreeGenerator::device = prng{device};
+//     }
+// };

--- a/src/tree/tree.hh
+++ b/src/tree/tree.hh
@@ -138,10 +138,10 @@ struct DefaultNodes : Types
             return child;
         };
 
-        size_t count_matrix_nodes()
+        size_t count_matrix_nodes() const
         {
             size_t c = 1;
-            ChanceNode *current = this->child;
+            const ChanceNode *current = this->child;
             while (current != nullptr)
             {
                 c += current->count_matrix_nodes();
@@ -264,10 +264,10 @@ struct DefaultNodes : Types
             return child;
         };
 
-        size_t count_matrix_nodes()
+        size_t count_matrix_nodes() const
         {
             size_t c = 0;
-            MatrixNode *current = this->child;
+            const MatrixNode *current = this->child;
             while (current != nullptr)
             {
                 c += current->count_matrix_nodes();

--- a/src/types/rational.hh
+++ b/src/types/rational.hh
@@ -86,6 +86,14 @@ struct Rational
         return *this;
     }
 
+    constexpr Rational &operator*=(Rational y)
+    {
+        p *= y.p;
+        q *= y.q;
+        return *this;
+    }
+
+
     friend std::ostream &operator<<(std::ostream &os, const Rational &x)
     {
         os << x.p << '/' << x.q;

--- a/src/types/wrapper.hh
+++ b/src/types/wrapper.hh
@@ -267,13 +267,6 @@ struct ObsHashType<std::array<uint8_t, 64>>
 template <>
 struct ObsHashType<std::array<uint8_t, 16>>
 {
-    size_t xs (size_t state) const
-    {
-        state ^= (state << 21);
-        state ^= (state >> 35);
-        state ^= (state << 4);
-        return state;
-    }
     size_t operator()(const ObsType<std::array<uint8_t, 16>> &obs) const
     {
         static const uint64_t duration_mask = 0xFFFFFFFFFF0FFFFF;

--- a/src/types/wrapper.hh
+++ b/src/types/wrapper.hh
@@ -263,23 +263,7 @@ struct ObsHashType<std::array<uint8_t, 64>>
         return hash;
     }
 };
-size_t hash_pair(size_t a, size_t b) {
-    size_t seed = 0;  // Initial seed value
-    constexpr size_t m = (size_t)-58;  // Large prime number
 
-    // Mix the bits of the first value
-    seed ^= a + m + (seed << 6) + (seed >> 2);
-
-    // Mix the bits of the second value
-    seed ^= b + m + (seed << 6) + (seed >> 2);
-
-    // Final mixing to ensure good distribution
-    seed += (seed << 3);
-    seed ^= (seed >> 11);
-    seed += (seed << 15);
-
-    return seed;
-}
 template <>
 struct ObsHashType<std::array<uint8_t, 16>>
 {
@@ -292,9 +276,11 @@ struct ObsHashType<std::array<uint8_t, 16>>
     }
     size_t operator()(const ObsType<std::array<uint8_t, 16>> &obs) const
     {
+        static const uint64_t duration_mask = 0xFFFFFFFFFF0FFFFF;
         const uint64_t *a = reinterpret_cast<const uint64_t *>(obs.value.data());
-        // return hash_pair(a[0], a[1]);
-        return ((a[0] << 32) >> 32) | (a[1] << 32);
+        const uint64_t side_1 = a[0] & duration_mask;
+        const uint64_t side_2 = a[1] & duration_mask;
+        return ((side_1 << 32) >> 32) | (side_2 << 32);
     }
 };
 

--- a/src/types/wrapper.hh
+++ b/src/types/wrapper.hh
@@ -23,10 +23,10 @@ struct ArithmeticType : Wrapper<T>
 
     void canonicalize()
     {
-        // if constexpr (requires std::is_same_v<decltype(std::declval<T>().myMethod()), void>) {
-        // this->value.canonicalize();
-
-        // }
+        if constexpr (std::is_same_v<mpq_class, T>)
+        {
+            this->value.canonicalize();
+        }
     }
 
     template <typename Integral>
@@ -279,7 +279,6 @@ struct ObsHashType<std::array<uint8_t, 376>>
         return hash;
     }
 };
-
 
 template <typename T>
 struct ActionType : Wrapper<T>

--- a/src/types/wrapper.hh
+++ b/src/types/wrapper.hh
@@ -265,6 +265,20 @@ struct ObsHashType<std::array<uint8_t, 64>>
 };
 
 template <>
+struct ObsHashType<std::array<uint8_t, 16>>
+{
+    size_t operator()(const ObsType<std::array<uint8_t, 16>> &obs) const
+    {
+        static const uint64_t duration_mask = 0xFFFFFFFFFF0FFFFF;
+        const uint64_t *a = reinterpret_cast<const uint64_t *>(obs.value.data());
+        const uint64_t side_1 = a[0] & duration_mask;
+        const uint64_t side_2 = a[1] & duration_mask;
+        return ((side_1 << 32) >> 32) | (side_2 << 32);
+    }
+};
+
+
+template <>
 struct ObsHashType<std::array<uint8_t, 376>>
 {
 

--- a/src/types/wrapper.hh
+++ b/src/types/wrapper.hh
@@ -265,19 +265,6 @@ struct ObsHashType<std::array<uint8_t, 64>>
 };
 
 template <>
-struct ObsHashType<std::array<uint8_t, 16>>
-{
-    size_t operator()(const ObsType<std::array<uint8_t, 16>> &obs) const
-    {
-        static const uint64_t duration_mask = 0xFFFFFFFFFF0FFFFF;
-        const uint64_t *a = reinterpret_cast<const uint64_t *>(obs.value.data());
-        const uint64_t side_1 = a[0] & duration_mask;
-        const uint64_t side_2 = a[1] & duration_mask;
-        return ((side_1 << 32) >> 32) | (side_2 << 32);
-    }
-};
-
-template <>
 struct ObsHashType<std::array<uint8_t, 376>>
 {
 

--- a/src/types/wrapper.hh
+++ b/src/types/wrapper.hh
@@ -264,6 +264,37 @@ struct ObsHashType<std::array<uint8_t, 64>>
     }
 };
 
+template <>
+struct ObsHashType<std::array<uint8_t, 16>>
+{
+    size_t operator()(const ObsType<std::array<uint8_t, 16>> &obs) const
+    {
+        const uint64_t *a = reinterpret_cast<const uint64_t *>(obs.value.data());
+        size_t hash = 0;
+        for (int i = 0; i < 2; ++i)
+        {
+            hash ^= a[i];
+        }
+        return hash;
+    }
+};
+
+template <>
+struct ObsHashType<std::array<uint8_t, 376>>
+{
+    size_t operator()(const ObsType<std::array<uint8_t, 376>> &obs) const
+    {
+        const uint64_t *a = reinterpret_cast<const uint64_t *>(obs.value.data());
+        size_t hash = 0;
+        for (int i = 0; i < 47; ++i)
+        {
+            hash ^= a[i];
+        }
+        return hash;
+    }
+};
+
+
 template <typename T>
 struct ActionType : Wrapper<T>
 {

--- a/src/types/wrapper.hh
+++ b/src/types/wrapper.hh
@@ -263,25 +263,45 @@ struct ObsHashType<std::array<uint8_t, 64>>
         return hash;
     }
 };
+size_t hash_pair(size_t a, size_t b) {
+    size_t seed = 0;  // Initial seed value
+    constexpr size_t m = (size_t)-58;  // Large prime number
 
+    // Mix the bits of the first value
+    seed ^= a + m + (seed << 6) + (seed >> 2);
+
+    // Mix the bits of the second value
+    seed ^= b + m + (seed << 6) + (seed >> 2);
+
+    // Final mixing to ensure good distribution
+    seed += (seed << 3);
+    seed ^= (seed >> 11);
+    seed += (seed << 15);
+
+    return seed;
+}
 template <>
 struct ObsHashType<std::array<uint8_t, 16>>
 {
+    size_t xs (size_t state) const
+    {
+        state ^= (state << 21);
+        state ^= (state >> 35);
+        state ^= (state << 4);
+        return state;
+    }
     size_t operator()(const ObsType<std::array<uint8_t, 16>> &obs) const
     {
         const uint64_t *a = reinterpret_cast<const uint64_t *>(obs.value.data());
-        size_t hash = 0;
-        for (int i = 0; i < 2; ++i)
-        {
-            hash ^= a[i];
-        }
-        return hash;
+        // return hash_pair(a[0], a[1]);
+        return ((a[0] << 32) >> 32) | (a[1] << 32);
     }
 };
 
 template <>
 struct ObsHashType<std::array<uint8_t, 376>>
 {
+
     size_t operator()(const ObsType<std::array<uint8_t, 376>> &obs) const
     {
         const uint64_t *a = reinterpret_cast<const uint64_t *>(obs.value.data());

--- a/tests/dynamic/arena.cc
+++ b/tests/dynamic/arena.cc
@@ -30,7 +30,7 @@ int main()
 
     using MCTypes = TreeBandit<Exp3<MonteCarloModel<FinalStateTypes>>>;
     // Exp3 search types on a solved random tree
-    using MCMTypes = TreeBanditSearchModel<MCTypes>;
+    using MCMTypes = SearchModel<MCTypes>;
     // Model type that treats search output as its inference
     using ArenaTypes = TreeBanditThreaded<Exp3Fat<MonteCarloModel<Arena>>>;
     // Type list for multithreaded exp3 over Arena state


### PR DESCRIPTION
Adding major changes from `pkmn-pinyon-test`'s version of Pinyon. These include:

`mapped_state` to give probabilities and `get_chance_actions` support to arbitrary states using sampling
`get_payoff()` over simple `.payoff` member. Allows for lazy computation of terminal values, which may be necessary like for the above utility
`SearchModel` improvements and changes to the `run` method of the various solvers to allow their inclusion
Rudimentary multithreading support for `FullTraversal`

Also a major bug was found in `AlphaBetaForce` and the fix/improvements need to be added to the normal impl.